### PR TITLE
feat: add SQLite store — schema and entity CRUD

### DIFF
--- a/brij/core/store.py
+++ b/brij/core/store.py
@@ -1,0 +1,241 @@
+"""SQLite-backed storage for entities and signals."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brij.core.models import Entity, Signal
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sources (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    connector_type TEXT NOT NULL,
+    config TEXT,
+    created_at TEXT NOT NULL,
+    last_synced_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS entities (
+    id TEXT PRIMARY KEY,
+    type TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    parent_id TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS signals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    value TEXT NOT NULL,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    origin TEXT NOT NULL DEFAULT 'source',
+    created_at TEXT NOT NULL,
+    UNIQUE(entity_id, kind, value),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS embeddings (
+    entity_id TEXT PRIMARY KEY,
+    vector BLOB NOT NULL,
+    model TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+"""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_dt(iso: str) -> datetime:
+    return datetime.fromisoformat(iso)
+
+
+class Store:
+    """SQLite store for Brij entities and signals."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._conn = sqlite3.connect(str(db_path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._conn.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    # --- Entity CRUD ---
+
+    def put_entity(self, entity: Entity) -> None:
+        """Insert or replace an entity and all its signals."""
+        with self._conn:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO entities"
+                " (id, type, source_id, parent_id, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    entity.id,
+                    entity.type,
+                    entity.source_id,
+                    entity.parent_id,
+                    entity.created_at.isoformat(),
+                    entity.updated_at.isoformat(),
+                ),
+            )
+            self._conn.execute("DELETE FROM signals WHERE entity_id = ?", (entity.id,))
+            for signal in entity.signals:
+                self._conn.execute(
+                    """INSERT INTO signals (entity_id, kind, value, confidence, origin, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        entity.id,
+                        signal.kind,
+                        signal.value,
+                        signal.confidence,
+                        signal.origin,
+                        signal.created_at.isoformat(),
+                    ),
+                )
+
+    def get_entity(self, entity_id: str) -> Entity | None:
+        """Return an entity with its signals, or None if not found."""
+        row = self._conn.execute(
+            "SELECT * FROM entities WHERE id = ?", (entity_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_entity(row)
+
+    def delete_entity(self, entity_id: str) -> bool:
+        """Delete an entity and its signals. Returns True if the entity existed."""
+        with self._conn:
+            cursor = self._conn.execute(
+                "DELETE FROM entities WHERE id = ?", (entity_id,)
+            )
+            return cursor.rowcount > 0
+
+    def _row_to_entity(self, row: sqlite3.Row) -> Entity:
+        signals = self._load_signals(row["id"])
+        return Entity(
+            id=row["id"],
+            type=row["type"],
+            source_id=row["source_id"],
+            parent_id=row["parent_id"],
+            created_at=_parse_dt(row["created_at"]),
+            updated_at=_parse_dt(row["updated_at"]),
+            signals=signals,
+        )
+
+    def _load_signals(self, entity_id: str) -> list[Signal]:
+        rows = self._conn.execute(
+            "SELECT kind, value, confidence, origin, created_at FROM signals WHERE entity_id = ?",
+            (entity_id,),
+        ).fetchall()
+        return [
+            Signal(
+                kind=r["kind"],
+                value=r["value"],
+                confidence=r["confidence"],
+                origin=r["origin"],
+                created_at=_parse_dt(r["created_at"]),
+            )
+            for r in rows
+        ]
+
+    # --- Signal operations ---
+
+    def add_signals(self, entity_id: str, signals: list[Signal]) -> None:
+        """Append signals to an existing entity without replacing existing ones."""
+        with self._conn:
+            for signal in signals:
+                self._conn.execute(
+                    """INSERT OR IGNORE INTO signals
+                       (entity_id, kind, value, confidence, origin, created_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        entity_id,
+                        signal.kind,
+                        signal.value,
+                        signal.confidence,
+                        signal.origin,
+                        signal.created_at.isoformat(),
+                    ),
+                )
+
+    # --- Query methods ---
+
+    def get_entities_by_source(self, source_id: str) -> list[Entity]:
+        """Return all entities belonging to a source."""
+        rows = self._conn.execute(
+            "SELECT * FROM entities WHERE source_id = ?", (source_id,)
+        ).fetchall()
+        return [self._row_to_entity(r) for r in rows]
+
+    def get_children(self, parent_id: str) -> list[Entity]:
+        """Return all entities with the given parent_id."""
+        rows = self._conn.execute(
+            "SELECT * FROM entities WHERE parent_id = ?", (parent_id,)
+        ).fetchall()
+        return [self._row_to_entity(r) for r in rows]
+
+    def get_entities_by_type(self, entity_type: str) -> list[Entity]:
+        """Return all entities of the given type."""
+        rows = self._conn.execute(
+            "SELECT * FROM entities WHERE type = ?", (entity_type,)
+        ).fetchall()
+        return [self._row_to_entity(r) for r in rows]
+
+    # --- Source management ---
+
+    def add_source(
+        self,
+        source_id: str,
+        name: str,
+        connector_type: str,
+        config: str | None = None,
+    ) -> None:
+        """Register a data source."""
+        with self._conn:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO sources (id, name, connector_type, config, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (source_id, name, connector_type, config, _now_iso()),
+            )
+
+    def get_sources(self) -> list[dict]:
+        """Return all registered sources."""
+        rows = self._conn.execute("SELECT * FROM sources").fetchall()
+        return [dict(r) for r in rows]
+
+    def update_source_synced(self, source_id: str) -> None:
+        """Update the last_synced_at timestamp for a source."""
+        with self._conn:
+            self._conn.execute(
+                "UPDATE sources SET last_synced_at = ? WHERE id = ?",
+                (_now_iso(), source_id),
+            )
+
+    # --- Statistics ---
+
+    def count_entities(self) -> int:
+        """Return the total number of entities."""
+        row = self._conn.execute("SELECT COUNT(*) as cnt FROM entities").fetchone()
+        return row["cnt"]
+
+    def count_signals(self) -> int:
+        """Return the total number of signals."""
+        row = self._conn.execute("SELECT COUNT(*) as cnt FROM signals").fetchone()
+        return row["cnt"]

--- a/tests/core/test_store.py
+++ b/tests/core/test_store.py
@@ -1,0 +1,195 @@
+"""Tests for SQLite store — schema and entity CRUD."""
+
+import pytest
+
+from brij.core.models import Entity, Signal
+from brij.core.store import Store
+
+
+@pytest.fixture
+def store():
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+def _make_entity(
+    id: str = "e1",
+    type: str = "record",
+    source_id: str = "s1",
+    parent_id: str | None = None,
+    signals: list[Signal] | None = None,
+) -> Entity:
+    return Entity(
+        id=id,
+        type=type,
+        source_id=source_id,
+        parent_id=parent_id,
+        signals=signals or [],
+    )
+
+
+class TestPutAndGetEntity:
+    def test_round_trip(self, store):
+        entity = _make_entity(signals=[Signal(kind="name", value="Alice")])
+        store.put_entity(entity)
+        loaded = store.get_entity("e1")
+        assert loaded is not None
+        assert loaded.id == "e1"
+        assert loaded.type == "record"
+        assert loaded.source_id == "s1"
+        assert len(loaded.signals) == 1
+        assert loaded.signals[0].kind == "name"
+        assert loaded.signals[0].value == "Alice"
+
+    def test_get_nonexistent_returns_none(self, store):
+        assert store.get_entity("nope") is None
+
+    def test_put_replaces_signals(self, store):
+        entity = _make_entity(signals=[Signal(kind="name", value="Alice")])
+        store.put_entity(entity)
+
+        entity.signals = [Signal(kind="name", value="Bob")]
+        store.put_entity(entity)
+
+        loaded = store.get_entity("e1")
+        assert len(loaded.signals) == 1
+        assert loaded.signals[0].value == "Bob"
+
+    def test_put_preserves_parent_id(self, store):
+        entity = _make_entity(parent_id="p1")
+        store.put_entity(entity)
+        loaded = store.get_entity("e1")
+        assert loaded.parent_id == "p1"
+
+    def test_multiple_signals(self, store):
+        entity = _make_entity(
+            signals=[
+                Signal(kind="name", value="Alice"),
+                Signal(kind="email", value="alice@example.com"),
+                Signal(kind="field:phone", value="555-1234"),
+            ]
+        )
+        store.put_entity(entity)
+        loaded = store.get_entity("e1")
+        assert len(loaded.signals) == 3
+
+
+class TestDeleteEntity:
+    def test_delete_existing(self, store):
+        store.put_entity(_make_entity())
+        assert store.delete_entity("e1") is True
+        assert store.get_entity("e1") is None
+
+    def test_delete_nonexistent(self, store):
+        assert store.delete_entity("nope") is False
+
+    def test_delete_cascades_signals(self, store):
+        entity = _make_entity(signals=[Signal(kind="name", value="Alice")])
+        store.put_entity(entity)
+        store.delete_entity("e1")
+        assert store.count_signals() == 0
+
+
+class TestAddSignals:
+    def test_appends_signals(self, store):
+        entity = _make_entity(signals=[Signal(kind="name", value="Alice")])
+        store.put_entity(entity)
+
+        store.add_signals("e1", [Signal(kind="email", value="alice@example.com")])
+
+        loaded = store.get_entity("e1")
+        assert len(loaded.signals) == 2
+        kinds = {s.kind for s in loaded.signals}
+        assert kinds == {"name", "email"}
+
+    def test_ignores_duplicate_signals(self, store):
+        entity = _make_entity(signals=[Signal(kind="name", value="Alice")])
+        store.put_entity(entity)
+
+        store.add_signals("e1", [Signal(kind="name", value="Alice")])
+
+        loaded = store.get_entity("e1")
+        assert len(loaded.signals) == 1
+
+
+class TestQueryMethods:
+    def test_get_entities_by_source(self, store):
+        store.put_entity(_make_entity(id="e1", source_id="s1"))
+        store.put_entity(_make_entity(id="e2", source_id="s1"))
+        store.put_entity(_make_entity(id="e3", source_id="s2"))
+
+        results = store.get_entities_by_source("s1")
+        assert len(results) == 2
+        assert {e.id for e in results} == {"e1", "e2"}
+
+    def test_get_children(self, store):
+        store.put_entity(_make_entity(id="parent", type="collection"))
+        store.put_entity(_make_entity(id="c1", parent_id="parent"))
+        store.put_entity(_make_entity(id="c2", parent_id="parent"))
+        store.put_entity(_make_entity(id="c3", parent_id="other"))
+
+        children = store.get_children("parent")
+        assert len(children) == 2
+        assert {e.id for e in children} == {"c1", "c2"}
+
+    def test_get_entities_by_type(self, store):
+        store.put_entity(_make_entity(id="e1", type="record"))
+        store.put_entity(_make_entity(id="e2", type="collection"))
+        store.put_entity(_make_entity(id="e3", type="record"))
+
+        records = store.get_entities_by_type("record")
+        assert len(records) == 2
+        assert {e.id for e in records} == {"e1", "e3"}
+
+    def test_get_entities_by_source_empty(self, store):
+        assert store.get_entities_by_source("nope") == []
+
+
+class TestSourceManagement:
+    def test_add_and_get_sources(self, store):
+        store.add_source("s1", "My CSV", "csv")
+        store.add_source("s2", "My Sheet", "google_sheets", config='{"key": "val"}')
+
+        sources = store.get_sources()
+        assert len(sources) == 2
+        names = {s["name"] for s in sources}
+        assert names == {"My CSV", "My Sheet"}
+
+    def test_update_source_synced(self, store):
+        store.add_source("s1", "My CSV", "csv")
+        sources = store.get_sources()
+        assert sources[0]["last_synced_at"] is None
+
+        store.update_source_synced("s1")
+        sources = store.get_sources()
+        assert sources[0]["last_synced_at"] is not None
+
+
+class TestStatistics:
+    def test_counts_empty(self, store):
+        assert store.count_entities() == 0
+        assert store.count_signals() == 0
+
+    def test_counts_after_inserts(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[
+                    Signal(kind="name", value="Alice"),
+                    Signal(kind="email", value="alice@example.com"),
+                ],
+            )
+        )
+        store.put_entity(_make_entity(id="e2"))
+
+        assert store.count_entities() == 2
+        assert store.count_signals() == 2
+
+    def test_counts_after_delete(self, store):
+        store.put_entity(
+            _make_entity(signals=[Signal(kind="name", value="Alice")])
+        )
+        store.delete_entity("e1")
+        assert store.count_entities() == 0
+        assert store.count_signals() == 0


### PR DESCRIPTION
## Summary
- Adds `brij/core/store.py` with SQLite-backed storage (WAL mode, foreign keys enabled)
- Four tables: `entities`, `signals` (UNIQUE on entity_id+kind+value), `embeddings`, `sources`
- Entity CRUD: `put_entity`, `get_entity`, `delete_entity` (cascading), `add_signals` (append without replace)
- Query methods: `get_entities_by_source`, `get_children`, `get_entities_by_type`
- Source management: `add_source`, `get_sources`, `update_source_synced`
- Statistics: `count_entities`, `count_signals`

## Test plan
- [x] 19 tests in `tests/core/test_store.py` using in-memory SQLite
- [x] CRUD round-trips verified
- [x] `put_entity` replaces signals on re-insert
- [x] `add_signals` appends without replacing
- [x] Delete cascades signals
- [x] Queries by source/type/parent return correct results
- [x] Stats are accurate after inserts and deletes
- [x] All 47 tests pass (`pytest tests/ -v`)
- [x] Lint clean (`ruff check brij/`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)