### PR TITLE
feat: add FTS5 keyword search to SQLite store

### DIFF
--- a/brij/core/store.py
+++ b/brij/core/store.py
@@ -49,6 +49,26 @@ CREATE TABLE IF NOT EXISTS embeddings (
     created_at TEXT NOT NULL,
     FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
 );
+
+CREATE VIRTUAL TABLE IF NOT EXISTS signals_fts
+    USING fts5(entity_id, kind, value, tokenize='porter');
+
+CREATE TRIGGER IF NOT EXISTS signals_ai AFTER INSERT ON signals BEGIN
+    INSERT INTO signals_fts(entity_id, kind, value)
+    VALUES (new.entity_id, new.kind, new.value);
+END;
+
+CREATE TRIGGER IF NOT EXISTS signals_au AFTER UPDATE ON signals BEGIN
+    DELETE FROM signals_fts
+    WHERE entity_id = old.entity_id AND kind = old.kind AND value = old.value;
+    INSERT INTO signals_fts(entity_id, kind, value)
+    VALUES (new.entity_id, new.kind, new.value);
+END;
+
+CREATE TRIGGER IF NOT EXISTS signals_ad AFTER DELETE ON signals BEGIN
+    DELETE FROM signals_fts
+    WHERE entity_id = old.entity_id AND kind = old.kind AND value = old.value;
+END;
 """
 
 
@@ -112,9 +132,7 @@ class Store:
 
     def get_entity(self, entity_id: str) -> Entity | None:
         """Return an entity with its signals, or None if not found."""
-        row = self._conn.execute(
-            "SELECT * FROM entities WHERE id = ?", (entity_id,)
-        ).fetchone()
+        row = self._conn.execute("SELECT * FROM entities WHERE id = ?", (entity_id,)).fetchone()
         if row is None:
             return None
         return self._row_to_entity(row)
@@ -122,9 +140,7 @@ class Store:
     def delete_entity(self, entity_id: str) -> bool:
         """Delete an entity and its signals. Returns True if the entity existed."""
         with self._conn:
-            cursor = self._conn.execute(
-                "DELETE FROM entities WHERE id = ?", (entity_id,)
-            )
+            cursor = self._conn.execute("DELETE FROM entities WHERE id = ?", (entity_id,))
             return cursor.rowcount > 0
 
     def _row_to_entity(self, row: sqlite3.Row) -> Entity:
@@ -239,3 +255,43 @@ class Store:
         """Return the total number of signals."""
         row = self._conn.execute("SELECT COUNT(*) as cnt FROM signals").fetchone()
         return row["cnt"]
+
+    # --- Full-text search ---
+
+    def keyword_search(
+        self,
+        query: str,
+        source_id: str | None = None,
+        limit: int = 20,
+    ) -> list[tuple[str, float]]:
+        """Search signals using FTS5 full-text search.
+
+        Returns a list of (entity_id, relevance_score) tuples,
+        deduplicated by entity, ordered by descending relevance.
+        """
+        if not query or not query.strip():
+            return []
+
+        if source_id is not None:
+            sql = """
+                SELECT f.entity_id, MAX(rank) AS relevance
+                FROM signals_fts f
+                JOIN entities e ON f.entity_id = e.id
+                WHERE signals_fts MATCH ? AND e.source_id = ?
+                GROUP BY f.entity_id
+                ORDER BY relevance
+                LIMIT ?
+            """
+            rows = self._conn.execute(sql, (query, source_id, limit)).fetchall()
+        else:
+            sql = """
+                SELECT entity_id, MAX(rank) AS relevance
+                FROM signals_fts
+                WHERE signals_fts MATCH ?
+                GROUP BY entity_id
+                ORDER BY relevance
+                LIMIT ?
+            """
+            rows = self._conn.execute(sql, (query, limit)).fetchall()
+
+        return [(row["entity_id"], -row["relevance"]) for row in rows]

--- a/tests/core/test_store_fts.py
+++ b/tests/core/test_store_fts.py
@@ -1,0 +1,193 @@
+"""Tests for SQLite store — FTS5 keyword search."""
+
+import pytest
+
+from brij.core.models import Entity, Signal
+from brij.core.store import Store
+
+
+@pytest.fixture
+def store():
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+def _make_entity(
+    id: str = "e1",
+    type: str = "record",
+    source_id: str = "s1",
+    parent_id: str | None = None,
+    signals: list[Signal] | None = None,
+) -> Entity:
+    return Entity(
+        id=id,
+        type=type,
+        source_id=source_id,
+        parent_id=parent_id,
+        signals=signals or [],
+    )
+
+
+class TestKeywordSearchByName:
+    def test_finds_entity_by_name(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice Johnson")])
+        )
+        results = store.keyword_search("Alice")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+        assert results[0][1] > 0
+
+    def test_finds_entity_by_email(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[Signal(kind="email", value="alice@example.com")],
+            )
+        )
+        results = store.keyword_search("alice")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+    def test_finds_entity_by_field_value(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[Signal(kind="field:company", value="Acme Corp")],
+            )
+        )
+        results = store.keyword_search("Acme")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+
+class TestKeywordSearchDedup:
+    def test_deduplicates_by_entity(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[
+                    Signal(kind="name", value="Alice Johnson"),
+                    Signal(kind="email", value="alice@example.com"),
+                    Signal(kind="field:notes", value="Alice is great"),
+                ],
+            )
+        )
+        results = store.keyword_search("Alice")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+
+class TestKeywordSearchSourceFilter:
+    def test_source_filter(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                source_id="s1",
+                signals=[Signal(kind="name", value="Alice")],
+            )
+        )
+        store.put_entity(
+            _make_entity(
+                id="e2",
+                source_id="s2",
+                signals=[Signal(kind="name", value="Alice Smith")],
+            )
+        )
+
+        results = store.keyword_search("Alice", source_id="s1")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+        results = store.keyword_search("Alice", source_id="s2")
+        assert len(results) == 1
+        assert results[0][0] == "e2"
+
+
+class TestKeywordSearchLimit:
+    def test_limit_is_respected(self, store):
+        for i in range(10):
+            store.put_entity(
+                _make_entity(
+                    id=f"e{i}",
+                    signals=[Signal(kind="name", value=f"Person {i}")],
+                )
+            )
+        results = store.keyword_search("Person", limit=3)
+        assert len(results) == 3
+
+
+class TestKeywordSearchEdgeCases:
+    def test_no_results_returns_empty(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice")])
+        )
+        results = store.keyword_search("Zebra")
+        assert results == []
+
+    def test_empty_query_returns_empty(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice")])
+        )
+        results = store.keyword_search("")
+        assert results == []
+
+    def test_whitespace_query_returns_empty(self, store):
+        results = store.keyword_search("   ")
+        assert results == []
+
+
+class TestKeywordSearchStemming:
+    def test_porter_stemmer_matches_variants(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[Signal(kind="field:notes", value="running quickly")],
+            )
+        )
+        # Porter stemmer reduces "running" and "run" to the same stem
+        results = store.keyword_search("run")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+    def test_stemmer_matches_plural(self, store):
+        store.put_entity(
+            _make_entity(
+                id="e1",
+                signals=[Signal(kind="field:notes", value="multiple clients")],
+            )
+        )
+        results = store.keyword_search("client")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+
+class TestFtsSyncTriggers:
+    def test_delete_entity_removes_from_fts(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice")])
+        )
+        store.delete_entity("e1")
+        results = store.keyword_search("Alice")
+        assert results == []
+
+    def test_put_entity_replaces_fts_entries(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice")])
+        )
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Bob")])
+        )
+        assert store.keyword_search("Alice") == []
+        results = store.keyword_search("Bob")
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+
+    def test_add_signals_updates_fts(self, store):
+        store.put_entity(
+            _make_entity(id="e1", signals=[Signal(kind="name", value="Alice")])
+        )
+        store.add_signals("e1", [Signal(kind="email", value="alice@example.com")])
+        results = store.keyword_search("alice")
+        assert len(results) == 1


### PR DESCRIPTION
## Summary
- Add `signals_fts` FTS5 virtual table with porter stemming tokenizer
- Add triggers to keep FTS index in sync on signal insert/update/delete
- Add `keyword_search(query, source_id=None, limit=20)` method returning deduplicated `(entity_id, relevance_score)` tuples ordered by relevance

Closes #5

## Test plan
- [x] Search finds entities by name, email, and field values
- [x] Results are deduplicated by entity
- [x] Source filter restricts results to a single source
- [x] Limit is respected
- [x] Empty/no-match queries return empty list
- [x] Porter stemmer matches word variants (run/running, client/clients)
- [x] FTS stays in sync after delete, replace, and add_signals operations
- [x] All 61 tests pass (14 new + 47 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)