### PR TITLE
feat: add config module with YAML persistence

### DIFF
--- a/brij/config.py
+++ b/brij/config.py
@@ -1,0 +1,86 @@
+"""Configuration module for Brij."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BRIJ_DIR = Path.home() / ".brij"
+
+
+@dataclass
+class SearchConfig:
+    """Configuration for search behavior."""
+
+    semantic_weight: float = 0.7
+    keyword_weight: float = 0.3
+    default_limit: int = 5
+    max_response_tokens: int = 2000
+
+
+@dataclass
+class EnrichmentConfig:
+    """Configuration for AI enrichment."""
+
+    enabled: bool = False
+    provider: str = "anthropic"
+    model: str = "claude-sonnet-4-5-20241022"
+
+
+@dataclass
+class Config:
+    """Top-level Brij configuration.
+
+    Config lives at ~/.brij/config.yaml by default.
+    """
+
+    brij_dir: Path = field(default_factory=lambda: DEFAULT_BRIJ_DIR)
+    search: SearchConfig = field(default_factory=SearchConfig)
+    enrichment: EnrichmentConfig = field(default_factory=EnrichmentConfig)
+
+    @property
+    def db_path(self) -> Path:
+        """Path to the SQLite database file."""
+        return self.brij_dir / "brij.db"
+
+    @classmethod
+    def load(cls, brij_dir: Path | None = None) -> Config:
+        """Load configuration from YAML file, returning defaults if it doesn't exist."""
+        brij_dir = brij_dir or DEFAULT_BRIJ_DIR
+        config_path = brij_dir / "config.yaml"
+
+        if not config_path.exists():
+            logger.debug("No config file at %s, using defaults", config_path)
+            return cls(brij_dir=brij_dir)
+
+        logger.debug("Loading config from %s", config_path)
+        with open(config_path) as f:
+            data = yaml.safe_load(f) or {}
+
+        search_data = data.get("search", {})
+        enrichment_data = data.get("enrichment", {})
+
+        return cls(
+            brij_dir=brij_dir,
+            search=SearchConfig(**search_data),
+            enrichment=EnrichmentConfig(**enrichment_data),
+        )
+
+    def save(self) -> None:
+        """Write configuration to YAML file."""
+        self.brij_dir.mkdir(parents=True, exist_ok=True)
+        config_path = self.brij_dir / "config.yaml"
+
+        data = {
+            "search": asdict(self.search),
+            "enrichment": asdict(self.enrichment),
+        }
+
+        logger.debug("Saving config to %s", config_path)
+        with open(config_path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ description = "Personal data connectivity layer for AI agents"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,92 @@
+"""Tests for the config module."""
+
+from pathlib import Path
+
+import pytest
+
+from brij.config import Config, EnrichmentConfig, SearchConfig
+
+
+class TestConfigDefaults:
+    """Test that default configuration values are correct."""
+
+    def test_load_returns_defaults_when_no_file_exists(self, tmp_path: Path) -> None:
+        config = Config.load(tmp_path)
+
+        assert config.brij_dir == tmp_path
+        assert config.search.semantic_weight == 0.7
+        assert config.search.keyword_weight == 0.3
+        assert config.search.default_limit == 5
+        assert config.search.max_response_tokens == 2000
+        assert config.enrichment.enabled is False
+        assert config.enrichment.provider == "anthropic"
+        assert config.enrichment.model == "claude-sonnet-4-5-20241022"
+
+    def test_db_path_is_under_brij_dir(self, tmp_path: Path) -> None:
+        config = Config.load(tmp_path)
+
+        assert config.db_path == tmp_path / "brij.db"
+
+
+class TestConfigRoundTrip:
+    """Test save and load round-trip."""
+
+    def test_save_then_load_round_trips(self, tmp_path: Path) -> None:
+        original = Config(brij_dir=tmp_path)
+        original.save()
+
+        loaded = Config.load(tmp_path)
+
+        assert loaded.search.semantic_weight == original.search.semantic_weight
+        assert loaded.search.keyword_weight == original.search.keyword_weight
+        assert loaded.search.default_limit == original.search.default_limit
+        assert loaded.search.max_response_tokens == original.search.max_response_tokens
+        assert loaded.enrichment.enabled == original.enrichment.enabled
+        assert loaded.enrichment.provider == original.enrichment.provider
+        assert loaded.enrichment.model == original.enrichment.model
+
+    def test_custom_values_are_preserved(self, tmp_path: Path) -> None:
+        original = Config(
+            brij_dir=tmp_path,
+            search=SearchConfig(
+                semantic_weight=0.5,
+                keyword_weight=0.5,
+                default_limit=10,
+                max_response_tokens=4000,
+            ),
+            enrichment=EnrichmentConfig(
+                enabled=True,
+                provider="openai",
+                model="gpt-4",
+            ),
+        )
+        original.save()
+
+        loaded = Config.load(tmp_path)
+
+        assert loaded.search.semantic_weight == 0.5
+        assert loaded.search.keyword_weight == 0.5
+        assert loaded.search.default_limit == 10
+        assert loaded.search.max_response_tokens == 4000
+        assert loaded.enrichment.enabled is True
+        assert loaded.enrichment.provider == "openai"
+        assert loaded.enrichment.model == "gpt-4"
+
+    def test_save_creates_brij_dir_if_missing(self, tmp_path: Path) -> None:
+        nested = tmp_path / "nested" / "brij"
+        config = Config(brij_dir=nested)
+        config.save()
+
+        assert (nested / "config.yaml").exists()
+
+    def test_config_file_is_valid_yaml(self, tmp_path: Path) -> None:
+        config = Config(brij_dir=tmp_path)
+        config.save()
+
+        import yaml
+
+        with open(tmp_path / "config.yaml") as f:
+            data = yaml.safe_load(f)
+
+        assert "search" in data
+        assert "enrichment" in data


### PR DESCRIPTION
## Summary
- Adds `brij/config.py` with `Config`, `SearchConfig`, and `EnrichmentConfig` dataclasses
- `Config.load(brij_dir)` reads YAML if it exists, returns defaults otherwise; `Config.save()` writes to disk
- Adds `pyyaml>=6.0` as a project dependency
- 6 new tests covering defaults, round-trip persistence, and custom value preservation

Closes #7

## Test plan
- [x] `pytest tests/test_config.py -v` — 6/6 pass
- [x] `pytest tests/ -v` — 82/82 pass
- [x] `ruff check brij/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)