### PR TITLE
feat: add CSV connector with discover phase

### DIFF
--- a/brij/connectors/csv_local.py
+++ b/brij/connectors/csv_local.py
@@ -1,0 +1,174 @@
+"""CSV local file connector — discover phase."""
+
+from __future__ import annotations
+
+import csv
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from brij.connectors.base import (
+    AuthenticationError,
+    BaseConnector,
+    SyncResult,
+)
+from brij.core.models import Entity, Signal
+
+logger = logging.getLogger(__name__)
+
+# Number of rows sampled for column type inference.
+_TYPE_SAMPLE_ROWS = 100
+
+
+def _infer_column_type(values: list[str]) -> str:
+    """Infer a column's data type from a sample of its values.
+
+    Returns one of: integer, float, boolean, date, text.
+    """
+    non_empty = [v for v in values if v.strip()]
+    if not non_empty:
+        return "text"
+
+    # Try integer
+    if all(_is_int(v) for v in non_empty):
+        return "integer"
+
+    # Try float
+    if all(_is_float(v) for v in non_empty):
+        return "float"
+
+    # Try boolean
+    if all(v.strip().lower() in ("true", "false", "yes", "no", "1", "0") for v in non_empty):
+        return "boolean"
+
+    return "text"
+
+
+def _is_int(value: str) -> bool:
+    try:
+        int(value.strip())
+        return True
+    except ValueError:
+        return False
+
+
+def _is_float(value: str) -> bool:
+    try:
+        float(value.strip())
+        return True
+    except ValueError:
+        return False
+
+
+class CsvLocalConnector(BaseConnector):
+    """Connector for local CSV files."""
+
+    def __init__(self) -> None:
+        self._path: Path | None = None
+        self._source_id: str = ""
+
+    def authenticate(self, credentials: dict) -> None:
+        """Validate that the CSV file exists.
+
+        Args:
+            credentials: Must contain ``{"path": "/path/to/file.csv"}``.
+
+        Raises:
+            AuthenticationError: If path is missing or the file does not exist.
+        """
+        raw_path = credentials.get("path")
+        if not raw_path:
+            raise AuthenticationError("credentials must include 'path'")
+
+        path = Path(raw_path)
+        if not path.is_file():
+            raise AuthenticationError(f"File not found: {path}")
+
+        self._path = path
+        self._source_id = f"csv:{path.name}"
+        logger.info("Authenticated CSV file: %s", path)
+
+    def discover(self) -> list[Entity]:
+        """Read the CSV header and return collection + field entities.
+
+        Returns:
+            A list containing one collection entity for the file and one
+            field entity per column.
+        """
+        if self._path is None:
+            raise AuthenticationError("authenticate() must be called before discover()")
+
+        stat = self._path.stat()
+        modified_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.reader(fh)
+            try:
+                headers = next(reader)
+            except StopIteration:
+                headers = []
+
+            # Count rows and sample values for type inference.
+            row_count = 0
+            samples: list[list[str]] = [[] for _ in headers]
+            for row in reader:
+                row_count += 1
+                if row_count <= _TYPE_SAMPLE_ROWS:
+                    for i, cell in enumerate(row):
+                        if i < len(headers):
+                            samples[i].append(cell)
+
+        # -- Collection entity --
+        collection_id = self.make_entity_id("collection", self._path.name)
+        collection = Entity(
+            id=collection_id,
+            type="collection",
+            source_id=self._source_id,
+            signals=[
+                Signal(kind="name", value=self._path.name),
+                Signal(kind="type", value="csv"),
+                Signal(kind="location", value=str(self._path.resolve())),
+                Signal(kind="modified", value=modified_at.isoformat()),
+                Signal(kind="row_count", value=str(row_count)),
+            ],
+        )
+
+        # -- Field entities (one per column) --
+        entities: list[Entity] = [collection]
+        for idx, header in enumerate(headers):
+            col_type = _infer_column_type(samples[idx] if idx < len(samples) else [])
+            field_id = self.make_entity_id("field", f"{self._path.name}:{header}")
+            entities.append(
+                Entity(
+                    id=field_id,
+                    type="field",
+                    source_id=self._source_id,
+                    parent_id=collection_id,
+                    signals=[
+                        Signal(kind="name", value=header),
+                        Signal(kind="type", value=col_type),
+                    ],
+                )
+            )
+
+        logger.info(
+            "Discovered %d columns and %d rows in %s",
+            len(headers),
+            row_count,
+            self._path.name,
+        )
+        return entities
+
+    # ----- Stubs for methods not yet implemented (Issue 8) -----
+
+    def read(self, entity_id: str) -> list[Signal]:
+        """Read signals for an entity (not yet implemented)."""
+        raise NotImplementedError("read() will be implemented in Issue 8")
+
+    def write(self, entity_id: str, data: dict) -> bool:
+        """Write data to an entity (not yet implemented)."""
+        raise NotImplementedError("write() will be implemented in a future issue")
+
+    def sync(self) -> SyncResult:
+        """Synchronize with the CSV file (not yet implemented)."""
+        raise NotImplementedError("sync() will be implemented in Issue 8")

--- a/tests/connectors/test_csv_local.py
+++ b/tests/connectors/test_csv_local.py
@@ -1,0 +1,160 @@
+"""Tests for the CSV local file connector — discover phase."""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from brij.connectors.base import AuthenticationError
+from brij.connectors.csv_local import CsvLocalConnector
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def csv_file(tmp_path: Path) -> Path:
+    """Create a simple fixture CSV with mixed column types."""
+    content = textwrap.dedent("""\
+        name,email,age,rate,active
+        Alice,alice@example.com,30,125.50,true
+        Bob,bob@example.com,45,200.00,false
+        Carol,carol@example.com,28,95.75,true
+    """)
+    path = tmp_path / "clients.csv"
+    path.write_text(content)
+    return path
+
+
+@pytest.fixture()
+def empty_csv(tmp_path: Path) -> Path:
+    """CSV with headers but no data rows."""
+    path = tmp_path / "empty.csv"
+    path.write_text("name,email\n")
+    return path
+
+
+@pytest.fixture()
+def headers_only_csv(tmp_path: Path) -> Path:
+    """CSV with only a header row and no trailing newline."""
+    path = tmp_path / "headers.csv"
+    path.write_text("col_a,col_b,col_c")
+    return path
+
+
+# ---- Authenticate ----
+
+
+class TestAuthenticate:
+    def test_valid_path(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        # No exception means success.
+
+    def test_missing_path_key(self) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="path"):
+            conn.authenticate({})
+
+    def test_nonexistent_file(self, tmp_path: Path) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="File not found"):
+            conn.authenticate({"path": str(tmp_path / "nope.csv")})
+
+    def test_empty_path_string(self) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="path"):
+            conn.authenticate({"path": ""})
+
+
+# ---- Discover ----
+
+
+class TestDiscover:
+    def test_collection_entity(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+
+        collection = entities[0]
+        assert collection.type == "collection"
+        assert collection.name == "clients.csv"
+        assert collection.get_signal_value("type") == "csv"
+        assert collection.get_signal_value("row_count") == "3"
+        assert collection.get_signal_value("location") == str(csv_file.resolve())
+        # modified signal should be a valid ISO timestamp
+        assert collection.get_signal_value("modified") is not None
+
+    def test_field_entities_match_headers(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+
+        fields = [e for e in entities if e.type == "field"]
+        field_names = [e.name for e in fields]
+        assert field_names == ["name", "email", "age", "rate", "active"]
+
+    def test_field_entities_are_children_of_collection(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+
+        collection = entities[0]
+        fields = [e for e in entities if e.type == "field"]
+        for f in fields:
+            assert f.parent_id == collection.id
+
+    def test_field_type_inference(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+
+        fields = {e.name: e for e in entities if e.type == "field"}
+        assert fields["name"].get_signal_value("type") == "text"
+        assert fields["email"].get_signal_value("type") == "text"
+        assert fields["age"].get_signal_value("type") == "integer"
+        assert fields["rate"].get_signal_value("type") == "float"
+        assert fields["active"].get_signal_value("type") == "boolean"
+
+    def test_total_entity_count(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+        # 1 collection + 5 fields
+        assert len(entities) == 6
+
+    def test_empty_csv_has_zero_rows(self, empty_csv: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(empty_csv)})
+        entities = conn.discover()
+
+        collection = entities[0]
+        assert collection.get_signal_value("row_count") == "0"
+        # Still has field entities for the headers
+        fields = [e for e in entities if e.type == "field"]
+        assert len(fields) == 2
+
+    def test_headers_only_csv(self, headers_only_csv: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(headers_only_csv)})
+        entities = conn.discover()
+
+        collection = entities[0]
+        assert collection.get_signal_value("row_count") == "0"
+        fields = [e for e in entities if e.type == "field"]
+        assert len(fields) == 3
+
+    def test_discover_before_authenticate_raises(self) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.discover()
+
+    def test_source_id_set_on_all_entities(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        entities = conn.discover()
+        for entity in entities:
+            assert entity.source_id == f"csv:{csv_file.name}"


### PR DESCRIPTION
## Summary
- Implements `brij/connectors/csv_local.py` — the first real connector
- `authenticate()` validates the CSV file exists at the given path
- `discover()` reads headers and returns one collection entity (with name, type, location, modified date, row count signals) and one field entity per column (with name and inferred type)
- Type inference samples up to 100 rows to detect integer, float, boolean, or text columns
- 13 tests covering auth errors, collection metadata, field matching, type inference, edge cases

Closes #9

## Test plan
- [x] `pytest tests/connectors/test_csv_local.py -v` — 13/13 pass
- [x] `pytest tests/ -v` — 95/95 pass (no regressions)
- [x] `ruff check brij/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)