### PR TITLE
feat: add CSV connector read and sync

### DIFF
--- a/brij/connectors/csv_local.py
+++ b/brij/connectors/csv_local.py
@@ -1,4 +1,4 @@
-"""CSV local file connector — discover phase."""
+"""CSV local file connector."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from pathlib import Path
 from brij.connectors.base import (
     AuthenticationError,
     BaseConnector,
+    EntityNotFoundError,
     SyncResult,
 )
 from brij.core.models import Entity, Signal
@@ -66,6 +67,7 @@ class CsvLocalConnector(BaseConnector):
     def __init__(self) -> None:
         self._path: Path | None = None
         self._source_id: str = ""
+        self._last_modified: datetime | None = None
 
     def authenticate(self, credentials: dict) -> None:
         """Validate that the CSV file exists.
@@ -100,6 +102,7 @@ class CsvLocalConnector(BaseConnector):
 
         stat = self._path.stat()
         modified_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+        self._last_modified = modified_at
 
         with open(self._path, newline="", encoding="utf-8") as fh:
             reader = csv.reader(fh)
@@ -159,16 +162,133 @@ class CsvLocalConnector(BaseConnector):
         )
         return entities
 
-    # ----- Stubs for methods not yet implemented (Issue 8) -----
+    def read(self, entity_id: str) -> list[Entity]:
+        """Read entities for a given entity ID.
 
-    def read(self, entity_id: str) -> list[Signal]:
-        """Read signals for an entity (not yet implemented)."""
-        raise NotImplementedError("read() will be implemented in Issue 8")
+        For a collection entity: returns one record entity per row, each with
+        ``field:{column_name}`` signals for every cell value.
+
+        For a record entity: returns a single-element list with that record's
+        field value signals.
+
+        Args:
+            entity_id: ID of the collection or record entity.
+
+        Returns:
+            List of record entities with field value signals.
+
+        Raises:
+            AuthenticationError: If authenticate() has not been called.
+            EntityNotFoundError: If the entity_id is not recognised.
+        """
+        if self._path is None:
+            raise AuthenticationError("authenticate() must be called before read()")
+
+        collection_id = self.make_entity_id("collection", self._path.name)
+
+        if entity_id == collection_id:
+            return self._read_all_rows()
+
+        if entity_id.startswith("record:"):
+            return self._read_single_row(entity_id)
+
+        raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+
+    def _read_all_rows(self) -> list[Entity]:
+        """Read every row in the CSV and return record entities."""
+        assert self._path is not None  # noqa: S101
+        entities: list[Entity] = []
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for row_idx, row in enumerate(reader):
+                record_id = self.make_entity_id(
+                    "record", f"{self._path.name}:{row_idx}"
+                )
+                collection_id = self.make_entity_id("collection", self._path.name)
+                signals = [
+                    Signal(kind=f"field:{col}", value=val)
+                    for col, val in row.items()
+                ]
+                entities.append(
+                    Entity(
+                        id=record_id,
+                        type="record",
+                        source_id=self._source_id,
+                        parent_id=collection_id,
+                        signals=signals,
+                    )
+                )
+        logger.info("Read %d rows from %s", len(entities), self._path.name)
+        return entities
+
+    def _read_single_row(self, entity_id: str) -> list[Entity]:
+        """Read a single row by its record entity ID."""
+        assert self._path is not None  # noqa: S101
+        # Parse the row index from the entity_id: "record:<filename>:<row_idx>"
+        suffix = entity_id[len("record:"):]
+        expected_prefix = f"{self._path.name}:"
+        if not suffix.startswith(expected_prefix):
+            raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+
+        try:
+            row_idx = int(suffix[len(expected_prefix):])
+        except ValueError:
+            raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            for current_idx, row in enumerate(reader):
+                if current_idx == row_idx:
+                    collection_id = self.make_entity_id("collection", self._path.name)
+                    signals = [
+                        Signal(kind=f"field:{col}", value=val)
+                        for col, val in row.items()
+                    ]
+                    return [
+                        Entity(
+                            id=entity_id,
+                            type="record",
+                            source_id=self._source_id,
+                            parent_id=collection_id,
+                            signals=signals,
+                        )
+                    ]
+
+        raise EntityNotFoundError(f"Row not found for entity: {entity_id}")
 
     def write(self, entity_id: str, data: dict) -> bool:
         """Write data to an entity (not yet implemented)."""
         raise NotImplementedError("write() will be implemented in a future issue")
 
     def sync(self) -> SyncResult:
-        """Synchronize with the CSV file (not yet implemented)."""
-        raise NotImplementedError("sync() will be implemented in Issue 8")
+        """Compare file modification time against stored timestamp.
+
+        Checks whether the CSV file has been modified since the last discover
+        or sync by comparing the current file mtime against the ``modified``
+        signal stored on the collection entity.
+
+        Returns:
+            SyncResult with the collection ID in ``modified`` if the file changed,
+            or an empty SyncResult if nothing changed.
+
+        Raises:
+            AuthenticationError: If authenticate() has not been called.
+        """
+        if self._path is None:
+            raise AuthenticationError("authenticate() must be called before sync()")
+
+        collection_id = self.make_entity_id("collection", self._path.name)
+        current_mtime = datetime.fromtimestamp(
+            self._path.stat().st_mtime, tz=timezone.utc
+        )
+
+        # If no baseline yet, capture it via discover.
+        if self._last_modified is None:
+            self.discover()
+
+        if current_mtime > self._last_modified:  # type: ignore[operator]
+            self._last_modified = current_mtime
+            logger.info("CSV file modified: %s", self._path.name)
+            return SyncResult(modified=[collection_id])
+
+        return SyncResult()

--- a/tests/connectors/test_csv_local.py
+++ b/tests/connectors/test_csv_local.py
@@ -1,14 +1,15 @@
-"""Tests for the CSV local file connector — discover phase."""
+"""Tests for the CSV local file connector."""
 
 from __future__ import annotations
 
 import os
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
 
-from brij.connectors.base import AuthenticationError
+from brij.connectors.base import AuthenticationError, EntityNotFoundError
 from brij.connectors.csv_local import CsvLocalConnector
 
 
@@ -158,3 +159,131 @@ class TestDiscover:
         entities = conn.discover()
         for entity in entities:
             assert entity.source_id == f"csv:{csv_file.name}"
+
+
+# ---- Read ----
+
+
+class TestRead:
+    def test_read_collection_returns_all_rows(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+        assert len(records) == 3
+
+    def test_every_row_is_a_record_entity(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+        for record in records:
+            assert record.type == "record"
+
+    def test_every_cell_is_a_field_signal(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+
+        first = records[0]
+        signal_kinds = {s.kind for s in first.signals}
+        assert signal_kinds == {
+            "field:name", "field:email", "field:age", "field:rate", "field:active"
+        }
+
+    def test_field_values_match_csv_content(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+
+        alice = records[0]
+        assert alice.get_signal_value("field:name") == "Alice"
+        assert alice.get_signal_value("field:email") == "alice@example.com"
+        assert alice.get_signal_value("field:age") == "30"
+
+    def test_records_are_tier_3(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+        for record in records:
+            assert record.tier == 3
+
+    def test_records_are_children_of_collection(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+        for record in records:
+            assert record.parent_id == collection_id
+
+    def test_read_single_record(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        record_id = conn.make_entity_id("record", f"{csv_file.name}:1")
+        records = conn.read(record_id)
+        assert len(records) == 1
+        assert records[0].get_signal_value("field:name") == "Bob"
+
+    def test_read_unknown_entity_raises(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        with pytest.raises(EntityNotFoundError):
+            conn.read("field:something")
+
+    def test_read_invalid_row_index_raises(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        with pytest.raises(EntityNotFoundError):
+            conn.read(conn.make_entity_id("record", f"{csv_file.name}:99"))
+
+    def test_read_before_authenticate_raises(self) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.read("collection:test.csv")
+
+    def test_source_id_set_on_records(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        records = conn.read(collection_id)
+        for record in records:
+            assert record.source_id == f"csv:{csv_file.name}"
+
+
+# ---- Sync ----
+
+
+class TestSync:
+    def test_sync_no_change(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        conn.discover()
+        result = conn.sync()
+        assert result.modified == []
+        assert result.new == []
+        assert result.deleted == []
+
+    def test_sync_detects_modified_file(self, csv_file: Path) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv_file)})
+        conn.discover()
+
+        # Ensure filesystem timestamp changes
+        time.sleep(0.05)
+        csv_file.write_text(
+            "name,email,age,rate,active\n"
+            "Alice,alice@example.com,30,125.50,true\n"
+            "Dave,dave@example.com,35,180.00,true\n"
+        )
+
+        result = conn.sync()
+        collection_id = conn.make_entity_id("collection", csv_file.name)
+        assert collection_id in result.modified
+
+    def test_sync_before_authenticate_raises(self) -> None:
+        conn = CsvLocalConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.sync()


### PR DESCRIPTION
## Summary
- Implement `read(entity_id)` on `CsvLocalConnector` — reading a collection returns record entities for all rows; reading a record returns that single row's field signals
- Every row becomes a record Entity with `field:{column_name}` signals (Tier 3)
- Implement `sync()` — compares file mtime against stored timestamp, returns modified if the file changed
- 14 new tests covering read (collection, single record, error cases) and sync (no-change, modified detection)

Closes #10

## Test plan
- [x] All 27 CSV connector tests pass (`pytest tests/connectors/test_csv_local.py -v`)
- [x] Full suite passes (109 tests)
- [x] `ruff check brij/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)