### PR TITLE
feat: add hybrid search merging keyword and semantic results (#15)

### DIFF
--- a/brij/core/store.py
+++ b/brij/core/store.py
@@ -277,6 +277,25 @@ class Store:
             return None
         return dict(row)
 
+    def get_all_embeddings(self, source_id: str | None = None) -> list[dict]:
+        """Return all embeddings, optionally filtered by source.
+
+        Each dict has keys: entity_id, vector, model, created_at.
+        """
+        if source_id is not None:
+            sql = """
+                SELECT emb.entity_id, emb.vector, emb.model, emb.created_at
+                FROM embeddings emb
+                JOIN entities e ON emb.entity_id = e.id
+                WHERE e.source_id = ?
+            """
+            rows = self._conn.execute(sql, (source_id,)).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT entity_id, vector, model, created_at FROM embeddings"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
     # --- Full-text search ---
 
     def keyword_search(

--- a/brij/search/engine.py
+++ b/brij/search/engine.py
@@ -5,25 +5,57 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 from brij.core.models import Entity
 
 if TYPE_CHECKING:
     from brij.config import SearchConfig
     from brij.core.store import Store
+    from brij.search.embeddings import EmbeddingEngine
 
 logger = logging.getLogger(__name__)
 
 
-class SearchEngine:
-    """Wraps the store's keyword search to return full Entity objects.
+def _normalize_scores(scored: dict[str, float]) -> dict[str, float]:
+    """Normalize scores to 0-1 range."""
+    if not scored:
+        return {}
+    values = list(scored.values())
+    min_val = min(values)
+    max_val = max(values)
+    span = max_val - min_val
+    if span == 0:
+        return {eid: 1.0 for eid in scored}
+    return {eid: (s - min_val) / span for eid, s in scored.items()}
 
-    This is the keyword-only search path. Semantic search will be
-    added in a future issue to produce hybrid results.
+
+def _cosine_similarity(a: bytes, b: bytes) -> float:
+    """Compute cosine similarity between two serialized float32 vectors."""
+    va = np.frombuffer(a, dtype=np.float32)
+    vb = np.frombuffer(b, dtype=np.float32)
+    dot = float(np.dot(va, vb))
+    norm = float(np.linalg.norm(va) * np.linalg.norm(vb))
+    if norm == 0:
+        return 0.0
+    return dot / norm
+
+
+class SearchEngine:
+    """Combines keyword and semantic search into hybrid results.
+
+    When no embedding engine is provided, falls back to keyword-only search.
     """
 
-    def __init__(self, store: Store, config: SearchConfig) -> None:
+    def __init__(
+        self,
+        store: Store,
+        config: SearchConfig,
+        embedding_engine: EmbeddingEngine | None = None,
+    ) -> None:
         self._store = store
         self._config = config
+        self._embedding_engine = embedding_engine
 
     def search(
         self,
@@ -31,17 +63,23 @@ class SearchEngine:
         sources: list[str] | None = None,
         limit: int | None = None,
     ) -> list[Entity]:
-        """Search for entities matching the query.
+        """Search for entities matching the query using hybrid ranking.
+
+        Combines keyword (FTS5) and semantic (cosine similarity) results.
+        Scores are normalized to 0-1 and merged at the configured ratio
+        (default 70% semantic / 30% keyword). Deduplicates by entity_id,
+        keeping the best combined score.
+
+        Falls back to keyword-only when no embedding engine is available.
 
         Args:
             query: The search query string.
             sources: Optional list of source IDs to filter by.
-                     When provided, results are restricted to these sources.
             limit: Maximum number of results to return.
                    Defaults to config.default_limit.
 
         Returns:
-            List of Entity objects ranked by keyword relevance.
+            List of Entity objects ranked by hybrid relevance.
         """
         if limit is None:
             limit = self._config.default_limit
@@ -49,17 +87,21 @@ class SearchEngine:
         if not query or not query.strip():
             return []
 
-        if sources:
-            # Run keyword search per source and merge by relevance.
-            scored: dict[str, float] = {}
-            for source_id in sources:
-                hits = self._store.keyword_search(query, source_id=source_id, limit=limit)
-                for entity_id, score in hits:
-                    if entity_id not in scored or score > scored[entity_id]:
-                        scored[entity_id] = score
-            ranked = sorted(scored.items(), key=lambda item: item[1], reverse=True)[:limit]
+        # Keyword path.
+        keyword_scored = self._keyword_search(query, sources, limit)
+
+        # Semantic path (when embedding engine is available).
+        semantic_scored: dict[str, float] = {}
+        if self._embedding_engine is not None:
+            semantic_scored = self._semantic_search(query, sources, limit)
+
+        # Merge.
+        if semantic_scored:
+            merged = self._merge_scores(keyword_scored, semantic_scored)
         else:
-            ranked = self._store.keyword_search(query, limit=limit)
+            merged = keyword_scored
+
+        ranked = sorted(merged.items(), key=lambda item: item[1], reverse=True)[:limit]
 
         entities: list[Entity] = []
         for entity_id, _score in ranked:
@@ -69,3 +111,71 @@ class SearchEngine:
 
         logger.debug("Search for %r returned %d entities", query, len(entities))
         return entities
+
+    def _keyword_search(
+        self,
+        query: str,
+        sources: list[str] | None,
+        limit: int,
+    ) -> dict[str, float]:
+        """Run keyword search, returning {entity_id: score}."""
+        if sources:
+            scored: dict[str, float] = {}
+            for source_id in sources:
+                hits = self._store.keyword_search(query, source_id=source_id, limit=limit)
+                for entity_id, score in hits:
+                    if entity_id not in scored or score > scored[entity_id]:
+                        scored[entity_id] = score
+            return scored
+        else:
+            return dict(self._store.keyword_search(query, limit=limit))
+
+    def _semantic_search(
+        self,
+        query: str,
+        sources: list[str] | None,
+        limit: int,
+    ) -> dict[str, float]:
+        """Embed the query and compute cosine similarity against stored embeddings."""
+        assert self._embedding_engine is not None
+        query_vector = self._embedding_engine.embed(query)
+
+        if sources:
+            all_embeddings: list[dict] = []
+            for source_id in sources:
+                all_embeddings.extend(self._store.get_all_embeddings(source_id=source_id))
+        else:
+            all_embeddings = self._store.get_all_embeddings()
+
+        if not all_embeddings:
+            return {}
+
+        scored: dict[str, float] = {}
+        for emb in all_embeddings:
+            sim = _cosine_similarity(query_vector, emb["vector"])
+            eid = emb["entity_id"]
+            if eid not in scored or sim > scored[eid]:
+                scored[eid] = sim
+
+        return scored
+
+    def _merge_scores(
+        self,
+        keyword_scored: dict[str, float],
+        semantic_scored: dict[str, float],
+    ) -> dict[str, float]:
+        """Normalize and merge keyword + semantic scores at configured ratio."""
+        kw_norm = _normalize_scores(keyword_scored)
+        sem_norm = _normalize_scores(semantic_scored)
+
+        kw_weight = self._config.keyword_weight
+        sem_weight = self._config.semantic_weight
+
+        all_ids = set(kw_norm) | set(sem_norm)
+        merged: dict[str, float] = {}
+        for eid in all_ids:
+            kw = kw_norm.get(eid, 0.0) * kw_weight
+            sem = sem_norm.get(eid, 0.0) * sem_weight
+            merged[eid] = kw + sem
+
+        return merged

--- a/tests/search/test_hybrid.py
+++ b/tests/search/test_hybrid.py
@@ -1,0 +1,214 @@
+"""Tests for hybrid search merging keyword and semantic results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from brij.config import SearchConfig
+from brij.connectors.csv_local import CsvLocalConnector
+from brij.core.models import Entity, Signal
+from brij.core.store import Store
+from brij.search.embeddings import EmbeddingEngine
+from brij.search.engine import SearchEngine, _normalize_scores
+
+
+@pytest.fixture()
+def store() -> Store:
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def config() -> SearchConfig:
+    return SearchConfig()
+
+
+@pytest.fixture()
+def embedding_engine() -> EmbeddingEngine:
+    return EmbeddingEngine()
+
+
+@pytest.fixture()
+def clients_csv(tmp_path: Path) -> Path:
+    """CSV with data designed to test semantic vs keyword gaps."""
+    content = (
+        "name,email,role,notes\n"
+        "Alice Johnson,alice@techvault.io,Engineer,Python data pipeline consultant\n"
+        "Bob Smith,bob@designlabs.co,Architect,Senior cloud infrastructure expert\n"
+        "Carol Davis,carol@brightspark.com,Designer,Mobile user experience specialist\n"
+        "Dave Wilson,dave@netcore.io,Manager,Left to start own company\n"
+        "Eve Martinez,eve@quantaml.ai,Scientist,Machine learning and AI researcher\n"
+    )
+    path = tmp_path / "clients.csv"
+    path.write_text(content)
+    return path
+
+
+def _load_and_embed(
+    csv_path: Path,
+    store: Store,
+    embedding_engine: EmbeddingEngine,
+) -> str:
+    """Connect CSV, store entities, and generate embeddings. Returns source_id."""
+    conn = CsvLocalConnector()
+    conn.authenticate({"path": str(csv_path)})
+
+    discovered = conn.discover()
+    for entity in discovered:
+        store.put_entity(entity)
+
+    collection_id = discovered[0].id
+    records = conn.read(collection_id)
+    for record in records:
+        store.put_entity(record)
+        embedding_engine.embed_entity(record, store)
+
+    return discovered[0].source_id
+
+
+class TestHybridFindsSemanticMatches:
+    """Hybrid search finds results that keyword alone misses."""
+
+    def test_semantic_match_on_meaning(
+        self,
+        clients_csv: Path,
+        store: Store,
+        config: SearchConfig,
+        embedding_engine: EmbeddingEngine,
+    ) -> None:
+        _load_and_embed(clients_csv, store, embedding_engine)
+
+        keyword_engine = SearchEngine(store, config)
+        hybrid_engine = SearchEngine(store, config, embedding_engine=embedding_engine)
+
+        # "artificial intelligence" won't keyword-match, but should
+        # semantically match Eve's "Machine learning and AI researcher".
+        keyword_results = keyword_engine.search("artificial intelligence", limit=5)
+        hybrid_results = hybrid_engine.search("artificial intelligence", limit=5)
+
+        keyword_ids = {e.id for e in keyword_results}
+        hybrid_ids = {e.id for e in hybrid_results}
+
+        # Hybrid should find at least one result that keyword missed.
+        assert len(hybrid_ids) > len(keyword_ids)
+
+    def test_synonym_match(
+        self,
+        clients_csv: Path,
+        store: Store,
+        config: SearchConfig,
+        embedding_engine: EmbeddingEngine,
+    ) -> None:
+        _load_and_embed(clients_csv, store, embedding_engine)
+        hybrid = SearchEngine(store, config, embedding_engine=embedding_engine)
+
+        # "UX" is semantically close to "user experience" (Carol's notes).
+        results = hybrid.search("UX", limit=5)
+        result_names = [e.get_signal_value("field:name") for e in results]
+        assert "Carol Davis" in result_names
+
+
+class TestDeduplication:
+    """Results are deduplicated by entity_id."""
+
+    def test_no_duplicate_entity_ids(
+        self,
+        clients_csv: Path,
+        store: Store,
+        config: SearchConfig,
+        embedding_engine: EmbeddingEngine,
+    ) -> None:
+        _load_and_embed(clients_csv, store, embedding_engine)
+        engine = SearchEngine(store, config, embedding_engine=embedding_engine)
+
+        results = engine.search("Engineer", limit=10)
+        ids = [e.id for e in results]
+        assert len(ids) == len(set(ids))
+
+
+class TestConfigRatioRespected:
+    """The configured semantic/keyword weight ratio affects ranking."""
+
+    def test_keyword_heavy_config(
+        self,
+        clients_csv: Path,
+        store: Store,
+        embedding_engine: EmbeddingEngine,
+    ) -> None:
+        """With 100% keyword weight, results match keyword-only search."""
+        _load_and_embed(clients_csv, store, embedding_engine)
+
+        keyword_config = SearchConfig(keyword_weight=1.0, semantic_weight=0.0)
+        keyword_only = SearchEngine(store, keyword_config)
+        keyword_heavy = SearchEngine(store, keyword_config, embedding_engine=embedding_engine)
+
+        query = "Alice"
+        kw_results = keyword_only.search(query, limit=5)
+        heavy_results = keyword_heavy.search(query, limit=5)
+
+        # Same top result when keyword weight is 100%.
+        assert kw_results[0].id == heavy_results[0].id
+
+    def test_semantic_heavy_config(
+        self,
+        clients_csv: Path,
+        store: Store,
+        embedding_engine: EmbeddingEngine,
+    ) -> None:
+        """With high semantic weight, semantic-only matches still appear."""
+        _load_and_embed(clients_csv, store, embedding_engine)
+
+        sem_config = SearchConfig(keyword_weight=0.0, semantic_weight=1.0)
+        engine = SearchEngine(store, sem_config, embedding_engine=embedding_engine)
+
+        # "artificial intelligence" has no keyword hit but semantic match.
+        results = engine.search("artificial intelligence", limit=5)
+        assert len(results) > 0
+
+
+class TestNormalizeScores:
+    """Unit tests for score normalization."""
+
+    def test_normalize_empty(self) -> None:
+        assert _normalize_scores({}) == {}
+
+    def test_normalize_single(self) -> None:
+        result = _normalize_scores({"a": 5.0})
+        assert result == {"a": 1.0}
+
+    def test_normalize_range(self) -> None:
+        result = _normalize_scores({"a": 1.0, "b": 3.0, "c": 5.0})
+        assert result["a"] == pytest.approx(0.0)
+        assert result["b"] == pytest.approx(0.5)
+        assert result["c"] == pytest.approx(1.0)
+
+    def test_normalize_all_same(self) -> None:
+        result = _normalize_scores({"a": 3.0, "b": 3.0})
+        assert result == {"a": 1.0, "b": 1.0}
+
+
+class TestFallbackToKeywordOnly:
+    """Without an embedding engine, search falls back to keyword-only."""
+
+    def test_no_embedding_engine(
+        self,
+        clients_csv: Path,
+        store: Store,
+        config: SearchConfig,
+    ) -> None:
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(clients_csv)})
+        discovered = conn.discover()
+        for entity in discovered:
+            store.put_entity(entity)
+        collection_id = discovered[0].id
+        for record in conn.read(collection_id):
+            store.put_entity(record)
+
+        engine = SearchEngine(store, config)
+        results = engine.search("Alice")
+        assert len(results) >= 1
+        assert results[0].get_signal_value("field:name") == "Alice Johnson"


### PR DESCRIPTION
## Summary
- Updates `SearchEngine.search()` to combine keyword (FTS5) and semantic (cosine similarity) results
- Normalizes both score lists to 0-1, merges at configured ratio (default 70% semantic / 30% keyword), deduplicates by entity_id keeping best score
- Adds `Store.get_all_embeddings()` for retrieving stored vectors with optional source filter
- Falls back to keyword-only search when no embedding engine is provided (backward compatible)

Closes #15

## Test plan
- [x] Hybrid search finds results that keyword alone misses (semantic match on meaning)
- [x] Synonym matching works (e.g. "UX" finds "user experience")
- [x] Results are deduplicated by entity_id
- [x] Config ratio is respected (keyword-heavy and semantic-heavy configs tested)
- [x] Score normalization edge cases (empty, single, uniform values)
- [x] Fallback to keyword-only without embedding engine
- [x] All 153 existing tests still pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)