### PR TITLE
feat: add MCP server search tool (#15)

### DIFF
--- a/brij/mcp/responses.py
+++ b/brij/mcp/responses.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from brij.core.models import Entity
     from brij.core.store import Store
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 # Approximate chars-per-token ratio for budget enforcement.
 _CHARS_PER_TOKEN = 4
 _DEFAULT_TOKEN_BUDGET = 2000
+_SEARCH_TOKEN_BUDGET = 3000
 
 
 def format_discover(store: Store, token_budget: int = _DEFAULT_TOKEN_BUDGET) -> str:
@@ -106,5 +108,93 @@ def format_discover(store: Store, token_budget: int = _DEFAULT_TOKEN_BUDGET) -> 
     max_chars = char_budget
     if len(result) > max_chars:
         result = result[:max_chars - 3] + "..."
+
+    return result
+
+
+def _format_entity_result(entity: Entity, store: Store) -> list[str]:
+    """Format a single entity as human-readable lines.
+
+    Includes source attribution, entity description, and key field values.
+    """
+    lines: list[str] = []
+
+    name = entity.name or entity.id
+    lines.append(f"- {name}")
+
+    # Source attribution.
+    sources = store.get_sources()
+    source_map = {s["id"]: s["name"] for s in sources}
+    source_name = source_map.get(entity.source_id, entity.source_id)
+    lines.append(f"  Source: {source_name}")
+
+    # Entity description from summary or preview signals.
+    summary = entity.summary
+    if summary:
+        lines.append(f"  {summary}")
+
+    # Key field values — show field:* signals.
+    field_signals = [s for s in entity.signals if s.kind.startswith("field:")]
+    for sig in field_signals:
+        field_name = sig.kind.removeprefix("field:")
+        lines.append(f"  {field_name}: {sig.value}")
+
+    return lines
+
+
+def format_search(
+    query: str,
+    results: list[Entity],
+    total_count: int,
+    offset: int,
+    limit: int,
+    store: Store,
+    token_budget: int = _SEARCH_TOKEN_BUDGET,
+) -> str:
+    """Build a plain-text search response.
+
+    Each result includes source name, entity description, and key field
+    values.  Includes total match count and pagination note.  Signal
+    internals (confidence, origin) never appear in the response.
+
+    Output stays under *token_budget* tokens.
+    """
+    if not results:
+        return (
+            f'No results found for "{query}".\n\n'
+            "Try different keywords or check that a data source is connected."
+        )
+
+    char_budget = token_budget * _CHARS_PER_TOKEN
+    lines: list[str] = [f'Search results for "{query}"', "=" * 40, ""]
+
+    for i, entity in enumerate(results, start=offset + 1):
+        entry_lines = [f"{i}."] + _format_entity_result(entity, store)
+        entry_lines.append("")
+
+        # Check budget before adding this entry.
+        candidate = "\n".join(lines + entry_lines)
+        if len(candidate) > char_budget - 200:
+            lines.append("... (results truncated to stay within budget)")
+            lines.append("")
+            break
+
+        lines.extend(entry_lines)
+
+    lines.append("-" * 40)
+
+    if total_count > offset + limit:
+        remaining = total_count - (offset + limit)
+        lines.append(
+            f"Showing {offset + 1}-{offset + len(results)} of {total_count} results. "
+            f"{remaining} more available."
+        )
+    else:
+        lines.append(f"Showing {offset + 1}-{offset + len(results)} of {total_count} results.")
+
+    result = "\n".join(lines)
+
+    if len(result) > char_budget:
+        result = result[:char_budget - 3] + "..."
 
     return result

--- a/brij/mcp/server.py
+++ b/brij/mcp/server.py
@@ -13,7 +13,7 @@ from mcp.server.fastmcp import FastMCP
 
 from brij.config import Config
 from brij.core.store import Store
-from brij.mcp.tools import discover
+from brij.mcp.tools import discover, search
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,31 @@ def brij_discover() -> str:
     store = _get_store()
     try:
         return discover(store)
+    finally:
+        store.close()
+
+
+@mcp.tool()
+def brij_search(
+    query: str,
+    sources: list[str] | None = None,
+    limit: int = 5,
+    offset: int = 0,
+) -> str:
+    """Search connected data sources.
+
+    Returns natural language formatted results with source attribution
+    and key field values for each match.
+
+    Args:
+        query: The search query string.
+        sources: Optional list of source IDs to filter results.
+        limit: Maximum number of results to return (default 5).
+        offset: Number of results to skip for pagination (default 0).
+    """
+    store = _get_store()
+    try:
+        return search(store, query, sources=sources, limit=limit, offset=offset)
     finally:
         store.close()
 

--- a/brij/mcp/tools.py
+++ b/brij/mcp/tools.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from brij.mcp.responses import format_discover
+from brij.config import SearchConfig
+from brij.mcp.responses import format_discover, format_search
+from brij.search.engine import SearchEngine
 
 if TYPE_CHECKING:
     from brij.core.store import Store
@@ -26,4 +28,51 @@ def discover(store: Store) -> str:
     logger.info("Running discover tool")
     result = format_discover(store)
     logger.debug("Discover returned %d characters", len(result))
+    return result
+
+
+def search(
+    store: Store,
+    query: str,
+    sources: list[str] | None = None,
+    limit: int = 5,
+    offset: int = 0,
+    search_config: SearchConfig | None = None,
+) -> str:
+    """Search connected data sources and return formatted results.
+
+    Args:
+        store: The Brij data store.
+        query: The search query string.
+        sources: Optional list of source IDs to filter by.
+        limit: Maximum results to return (default 5).
+        offset: Number of results to skip for pagination (default 0).
+        search_config: Optional search configuration override.
+
+    Returns:
+        Plain-text formatted search results.
+    """
+    logger.info("Running search tool: query=%r, sources=%r, limit=%d, offset=%d",
+                query, sources, limit, offset)
+
+    config = search_config or SearchConfig()
+    engine = SearchEngine(store, config)
+
+    # Fetch enough results to cover offset + limit.
+    fetch_limit = offset + limit
+    all_results = engine.search(query, sources=sources, limit=fetch_limit)
+    total_count = len(all_results)
+
+    # Apply offset.
+    paged_results = all_results[offset:]
+
+    result = format_search(
+        query=query,
+        results=paged_results,
+        total_count=total_count,
+        offset=offset,
+        limit=limit,
+        store=store,
+    )
+    logger.debug("Search returned %d characters", len(result))
     return result

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -8,8 +8,8 @@ import pytest
 
 from brij.connectors.csv_local import CsvLocalConnector
 from brij.core.store import Store
-from brij.mcp.responses import _CHARS_PER_TOKEN, _DEFAULT_TOKEN_BUDGET
-from brij.mcp.tools import discover
+from brij.mcp.responses import _CHARS_PER_TOKEN, _DEFAULT_TOKEN_BUDGET, _SEARCH_TOKEN_BUDGET
+from brij.mcp.tools import discover, search
 
 
 @pytest.fixture()
@@ -134,3 +134,111 @@ class TestDiscover:
 
         assert not result.strip().startswith("{")
         assert not result.strip().startswith("[")
+
+
+class TestSearch:
+    """Tests for the search tool."""
+
+    def test_search_returns_formatted_text(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Search returns human-readable text, not JSON."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "Alice")
+
+        assert "Search results" in result
+        assert "Alice" in result
+        assert not result.strip().startswith("{")
+        assert not result.strip().startswith("[")
+
+    def test_results_include_source_attribution(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Each result includes the source name."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "Alice")
+
+        assert "Source:" in result
+        assert "clients" in result
+
+    def test_results_include_field_values(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Results include key field values from field:* signals."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "Alice")
+
+        assert "alice@example.com" in result
+
+    def test_pagination_works(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Offset and limit control which results are shown."""
+        _connect_source(clients_csv, store)
+
+        result_page1 = search(store, "example", limit=2, offset=0)
+        result_page2 = search(store, "example", limit=2, offset=2)
+
+        assert "1." in result_page1
+        assert "2." in result_page1
+        assert "3." in result_page2
+
+    def test_empty_results_return_helpful_message(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """No matches returns a helpful message."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "zzzznonexistent")
+
+        assert "No results" in result
+        assert "zzzznonexistent" in result
+
+    def test_empty_query_returns_no_results(self, store: Store) -> None:
+        """Empty query returns no results message."""
+        result = search(store, "")
+
+        assert "No results" in result
+
+    def test_response_under_token_budget(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Response stays under the 3000 token budget."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "example", limit=10)
+
+        max_chars = _SEARCH_TOKEN_BUDGET * _CHARS_PER_TOKEN
+        assert len(result) <= max_chars
+
+    def test_signal_internals_not_exposed(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Confidence and origin values should not appear in results."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "Alice")
+
+        assert "confidence" not in result.lower()
+        assert "origin" not in result.lower()
+
+    def test_source_filter(
+        self, tmp_path: Path, store: Store
+    ) -> None:
+        """Source filter limits results to the specified source."""
+        csv1 = tmp_path / "contacts.csv"
+        csv1.write_text("name,phone\nAlice,555-1234\n")
+
+        csv2 = tmp_path / "projects.csv"
+        csv2.write_text("name,status\nAlice Project,Active\n")
+
+        source1 = _connect_source(csv1, store)
+        _connect_source(csv2, store)
+
+        result = search(store, "Alice", sources=[source1])
+
+        assert "contacts" in result
+        assert "projects" not in result.lower() or "Project" not in result


### PR DESCRIPTION
## Summary
- Add `search` tool to MCP server accepting query, sources, limit, and offset parameters
- Returns natural language formatted results with source attribution and key field values
- Signal internals (confidence, origin) drive ranking but never appear in the response
- Response stays under 3,000 token budget with pagination support

Closes #17

## Test plan
- [x] Search returns formatted text (not JSON)
- [x] Results include source attribution
- [x] Results include field values
- [x] Pagination with offset/limit works
- [x] Empty results return helpful message
- [x] Response stays under token budget
- [x] Signal internals not exposed
- [x] Source filter works
- [x] All 169 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)