### PR TITLE
feat: add MCP server write tool

### DIFF
--- a/brij/connectors/csv_local.py
+++ b/brij/connectors/csv_local.py
@@ -12,6 +12,7 @@ from brij.connectors.base import (
     BaseConnector,
     EntityNotFoundError,
     SyncResult,
+    WriteError,
 )
 from brij.core.models import Entity, Signal
 
@@ -257,8 +258,164 @@ class CsvLocalConnector(BaseConnector):
         raise EntityNotFoundError(f"Row not found for entity: {entity_id}")
 
     def write(self, entity_id: str, data: dict) -> bool:
-        """Write data to an entity (not yet implemented)."""
-        raise NotImplementedError("write() will be implemented in a future issue")
+        """Write data back to the CSV source.
+
+        The ``data`` dict must include an ``"action"`` key set to one of
+        ``"add"``, ``"update"``, or ``"delete"``.  For ``"add"`` and
+        ``"update"``, a ``"fields"`` dict mapping column names to values
+        is required.
+
+        Args:
+            entity_id: The collection ID (for add) or record ID (for update/delete).
+            data: Action descriptor with ``action`` and optional ``fields``.
+
+        Returns:
+            True if the write succeeded.
+
+        Raises:
+            AuthenticationError: If authenticate() has not been called.
+            WriteError: If the action is unknown or the write fails.
+            EntityNotFoundError: If the target row does not exist.
+        """
+        if self._path is None:
+            raise AuthenticationError("authenticate() must be called before write()")
+
+        action = data.get("action")
+        if action == "add":
+            return self._add_record(data.get("fields", {}))
+        elif action == "update":
+            return self._update_record(entity_id, data.get("fields", {}))
+        elif action == "delete":
+            return self._delete_record(entity_id)
+        else:
+            raise WriteError(f"Unknown write action: {action}")
+
+    def _add_record(self, fields: dict) -> bool:
+        """Append a new row to the CSV file."""
+        assert self._path is not None  # noqa: S101
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.reader(fh)
+            try:
+                headers = next(reader)
+            except StopIteration:
+                raise WriteError("CSV file has no header row")
+
+        row = [str(fields.get(h, "")) for h in headers]
+        with open(self._path, "a", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(row)
+
+        logger.info("Added record to %s", self._path.name)
+        return True
+
+    def _update_record(self, entity_id: str, fields: dict) -> bool:
+        """Update a row in the CSV file by record entity ID."""
+        assert self._path is not None  # noqa: S101
+        row_idx = self._parse_row_index(entity_id)
+
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            headers = list(reader.fieldnames or [])
+            rows = list(reader)
+
+        if row_idx >= len(rows):
+            raise EntityNotFoundError(f"Row not found for entity: {entity_id}")
+
+        for key, value in fields.items():
+            if key in headers:
+                rows[row_idx][key] = str(value)
+
+        self._write_csv(headers, rows)
+        logger.info("Updated record %s in %s", entity_id, self._path.name)
+        return True
+
+    def _delete_record(self, entity_id: str) -> bool:
+        """Delete a row from the CSV file by record entity ID."""
+        assert self._path is not None  # noqa: S101
+        row_idx = self._parse_row_index(entity_id)
+
+        with open(self._path, newline="", encoding="utf-8") as fh:
+            reader = csv.DictReader(fh)
+            headers = list(reader.fieldnames or [])
+            rows = list(reader)
+
+        if row_idx >= len(rows):
+            raise EntityNotFoundError(f"Row not found for entity: {entity_id}")
+
+        rows.pop(row_idx)
+        self._write_csv(headers, rows)
+        logger.info("Deleted record %s from %s", entity_id, self._path.name)
+        return True
+
+    def _parse_row_index(self, entity_id: str) -> int:
+        """Extract the row index from a record entity ID."""
+        assert self._path is not None  # noqa: S101
+        if not entity_id.startswith("record:"):
+            raise EntityNotFoundError(f"Not a record entity: {entity_id}")
+        suffix = entity_id[len("record:"):]
+        expected_prefix = f"{self._path.name}:"
+        if not suffix.startswith(expected_prefix):
+            raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+        try:
+            return int(suffix[len(expected_prefix):])
+        except ValueError:
+            raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+
+    def _write_csv(self, headers: list[str], rows: list[dict]) -> None:
+        """Rewrite the entire CSV file with the given headers and rows."""
+        assert self._path is not None  # noqa: S101
+        with open(self._path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=headers)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def create_collection(self, name: str, schema: dict) -> Entity:
+        """Create a new CSV file with the given column headers.
+
+        Args:
+            name: Name for the new collection (used as the filename stem).
+            schema: Must contain ``"fields"`` — a list of column name strings.
+
+        Returns:
+            The created collection entity.
+
+        Raises:
+            AuthenticationError: If authenticate() has not been called.
+            WriteError: If the file already exists or fields are empty.
+        """
+        if self._path is None:
+            raise AuthenticationError("authenticate() must be called before create_collection()")
+
+        fields = schema.get("fields", [])
+        if not fields:
+            raise WriteError("schema must include a non-empty 'fields' list")
+
+        new_path = self._path.parent / f"{name}.csv"
+        if new_path.exists():
+            raise WriteError(f"File already exists: {new_path}")
+
+        with open(new_path, "w", newline="", encoding="utf-8") as fh:
+            writer = csv.writer(fh)
+            writer.writerow(fields)
+
+        collection_id = self.make_entity_id("collection", new_path.name)
+        now = datetime.now(timezone.utc)
+        collection = Entity(
+            id=collection_id,
+            type="collection",
+            source_id=self._source_id,
+            signals=[
+                Signal(kind="name", value=new_path.name),
+                Signal(kind="type", value="csv"),
+                Signal(kind="location", value=str(new_path.resolve())),
+                Signal(kind="row_count", value="0"),
+            ],
+            created_at=now,
+            updated_at=now,
+        )
+
+        logger.info("Created collection %s at %s", name, new_path)
+        return collection
 
     def sync(self) -> SyncResult:
         """Compare file modification time against stored timestamp.

--- a/brij/mcp/responses.py
+++ b/brij/mcp/responses.py
@@ -198,3 +198,53 @@ def format_search(
         result = result[:char_budget - 3] + "..."
 
     return result
+
+
+def format_write(
+    action: str,
+    entity_id: str | None = None,
+    data: dict | None = None,
+) -> str:
+    """Build a plain-text confirmation for a write operation.
+
+    Args:
+        action: The write action performed (create, add, update, delete).
+        entity_id: The entity affected by the write.
+        data: Field data involved in the write.
+
+    Returns:
+        A human-readable confirmation string.
+    """
+    data = data or {}
+
+    if action == "create":
+        name = data.get("name", "")
+        fields = data.get("fields", [])
+        lines = [
+            f"Created collection '{name}'.",
+            f"Fields: {', '.join(fields)}" if fields else "",
+            f"Entity ID: {entity_id}" if entity_id else "",
+        ]
+        return "\n".join(line for line in lines if line)
+
+    if action == "add":
+        fields_str = ", ".join(f"{k}: {v}" for k, v in data.items())
+        lines = [
+            "Added record.",
+            f"Entity ID: {entity_id}" if entity_id else "",
+            f"Fields: {fields_str}" if fields_str else "",
+        ]
+        return "\n".join(line for line in lines if line)
+
+    if action == "update":
+        fields_str = ", ".join(f"{k}: {v}" for k, v in data.items())
+        lines = [
+            f"Updated record {entity_id}.",
+            f"Modified fields: {fields_str}" if fields_str else "",
+        ]
+        return "\n".join(line for line in lines if line)
+
+    if action == "delete":
+        return f"Deleted record {entity_id}."
+
+    return f"Write completed (action={action})."

--- a/brij/mcp/server.py
+++ b/brij/mcp/server.py
@@ -13,7 +13,7 @@ from mcp.server.fastmcp import FastMCP
 
 from brij.config import Config
 from brij.core.store import Store
-from brij.mcp.tools import discover, search
+from brij.mcp.tools import discover, search, write
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,41 @@ def brij_search(
     store = _get_store()
     try:
         return search(store, query, sources=sources, limit=limit, offset=offset)
+    finally:
+        store.close()
+
+
+@mcp.tool()
+def brij_write(
+    action: str,
+    source_id: str,
+    collection_id: str | None = None,
+    entity_id: str | None = None,
+    data: dict | None = None,
+) -> str:
+    """Write to a connected data source.
+
+    Changes flow through the connector back to the original source.
+    Returns a confirmation of what changed.
+
+    Args:
+        action: The write action — "create", "add", "update", or "delete".
+        source_id: The source to write to.
+        collection_id: Target collection (required for "add").
+        entity_id: Target record (required for "update" and "delete").
+        data: Field data. For "create": {"name": "...", "fields": [...]}.
+              For "add"/"update": {"field_name": "value", ...}.
+    """
+    store = _get_store()
+    try:
+        return write(
+            store,
+            action=action,
+            source_id=source_id,
+            collection_id=collection_id,
+            entity_id=entity_id,
+            data=data,
+        )
     finally:
         store.close()
 

--- a/brij/mcp/tools.py
+++ b/brij/mcp/tools.py
@@ -6,13 +6,18 @@ import logging
 from typing import TYPE_CHECKING
 
 from brij.config import SearchConfig
-from brij.mcp.responses import format_discover, format_search
+from brij.connectors.base import WriteError
+from brij.core.models import Entity, Signal
+from brij.mcp.responses import format_discover, format_search, format_write
 from brij.search.engine import SearchEngine
 
 if TYPE_CHECKING:
+    from brij.connectors.base import BaseConnector
     from brij.core.store import Store
 
 logger = logging.getLogger(__name__)
+
+_VALID_WRITE_ACTIONS = ("create", "add", "update", "delete")
 
 
 def discover(store: Store) -> str:
@@ -76,3 +81,229 @@ def search(
     )
     logger.debug("Search returned %d characters", len(result))
     return result
+
+
+def _get_connector_for_source(store: Store, source_id: str) -> BaseConnector:
+    """Instantiate and authenticate a connector for the given source.
+
+    Looks up the source's connector type and resolves the file path
+    from the collection entity's ``location`` signal.
+
+    Args:
+        store: The Brij data store.
+        source_id: The source to get a connector for.
+
+    Returns:
+        An authenticated connector instance.
+
+    Raises:
+        WriteError: If the source or connector type is unknown.
+    """
+    sources = store.get_sources()
+    source = next((s for s in sources if s["id"] == source_id), None)
+    if source is None:
+        raise WriteError(f"Unknown source: {source_id}")
+
+    connector_type = source["connector_type"]
+    if connector_type == "csv_local":
+        collections = store.get_entities_by_type("collection")
+        collection = next(
+            (c for c in collections if c.source_id == source_id), None
+        )
+        if collection is None:
+            raise WriteError(f"No collection found for source: {source_id}")
+
+        path = collection.get_signal_value("location")
+        if path is None:
+            raise WriteError(f"No file path for collection: {collection.id}")
+
+        from brij.connectors.csv_local import CsvLocalConnector
+
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": path})
+        return conn
+
+    raise WriteError(f"Unsupported connector type: {connector_type}")
+
+
+def write(
+    store: Store,
+    action: str,
+    source_id: str,
+    collection_id: str | None = None,
+    entity_id: str | None = None,
+    data: dict | None = None,
+) -> str:
+    """Execute a write action against a connected data source.
+
+    Changes flow through the connector's write path back to the
+    original source, then the store is updated to match.
+
+    Args:
+        store: The Brij data store.
+        action: One of ``"create"``, ``"add"``, ``"update"``, ``"delete"``.
+        source_id: The source to write to.
+        collection_id: Required for ``"add"`` — the target collection.
+        entity_id: Required for ``"update"`` and ``"delete"`` — the target record.
+        data: Field data for ``"create"``, ``"add"``, and ``"update"``.
+
+    Returns:
+        Plain-text confirmation of what changed.
+    """
+    logger.info("Running write tool: action=%s, source_id=%s", action, source_id)
+
+    if action not in _VALID_WRITE_ACTIONS:
+        return (
+            f"Invalid action '{action}'. "
+            f"Must be one of: {', '.join(_VALID_WRITE_ACTIONS)}"
+        )
+
+    data = data or {}
+    connector = _get_connector_for_source(store, source_id)
+
+    if action == "create":
+        return _write_create(store, connector, source_id, data)
+    if action == "add":
+        if collection_id is None:
+            return "collection_id is required for 'add' action."
+        return _write_add(store, connector, source_id, collection_id, data)
+    if action == "update":
+        if entity_id is None:
+            return "entity_id is required for 'update' action."
+        return _write_update(store, connector, source_id, entity_id, data)
+    # action == "delete"
+    if entity_id is None:
+        return "entity_id is required for 'delete' action."
+    return _write_delete(store, connector, source_id, entity_id)
+
+
+def _write_create(
+    store: Store,
+    connector: BaseConnector,
+    source_id: str,
+    data: dict,
+) -> str:
+    """Handle the 'create' action — create a new collection."""
+    name = data.get("name", "")
+    if not name:
+        return "data must include 'name' for create action."
+
+    fields = data.get("fields", [])
+    if not fields:
+        return "data must include a non-empty 'fields' list for create action."
+
+    collection = connector.create_collection(name, {"fields": fields})
+    store.put_entity(collection)
+
+    # Create field entities for each column.
+    for field_name in fields:
+        field_id = connector.make_entity_id("field", f"{name}.csv:{field_name}")
+        field_entity = Entity(
+            id=field_id,
+            type="field",
+            source_id=source_id,
+            parent_id=collection.id,
+            signals=[
+                Signal(kind="name", value=field_name),
+                Signal(kind="type", value="text"),
+            ],
+        )
+        store.put_entity(field_entity)
+
+    return format_write(
+        action="create",
+        entity_id=collection.id,
+        data={"name": name, "fields": fields},
+    )
+
+
+def _write_add(
+    store: Store,
+    connector: BaseConnector,
+    source_id: str,
+    collection_id: str,
+    data: dict,
+) -> str:
+    """Handle the 'add' action — add a new record to a collection."""
+    # Count existing records to determine the new row index.
+    records = [
+        e for e in store.get_entities_by_type("record")
+        if e.parent_id == collection_id
+    ]
+    new_row_idx = len(records)
+
+    # Write through to source.
+    connector.write(collection_id, {"action": "add", "fields": data})
+
+    # Create the record entity in the store.
+    filename = collection_id.removeprefix("collection:")
+    record_id = connector.make_entity_id("record", f"{filename}:{new_row_idx}")
+    signals = [Signal(kind=f"field:{k}", value=str(v)) for k, v in data.items()]
+    entity = Entity(
+        id=record_id,
+        type="record",
+        source_id=source_id,
+        parent_id=collection_id,
+        signals=signals,
+    )
+    store.put_entity(entity)
+
+    return format_write(action="add", entity_id=record_id, data=data)
+
+
+def _write_update(
+    store: Store,
+    connector: BaseConnector,
+    source_id: str,
+    entity_id: str,
+    data: dict,
+) -> str:
+    """Handle the 'update' action — modify fields on an existing record."""
+    existing = store.get_entity(entity_id)
+    if existing is None:
+        return f"Entity not found: {entity_id}"
+
+    # Write through to source.
+    connector.write(entity_id, {"action": "update", "fields": data})
+
+    # Update the entity's signals in the store.
+    updated_signals: list[Signal] = []
+    for sig in existing.signals:
+        field_name = sig.kind.removeprefix("field:")
+        if sig.kind.startswith("field:") and field_name in data:
+            updated_signals.append(
+                Signal(kind=sig.kind, value=str(data[field_name]))
+            )
+        else:
+            updated_signals.append(sig)
+
+    updated_entity = Entity(
+        id=existing.id,
+        type=existing.type,
+        source_id=existing.source_id,
+        parent_id=existing.parent_id,
+        signals=updated_signals,
+    )
+    store.put_entity(updated_entity)
+
+    return format_write(action="update", entity_id=entity_id, data=data)
+
+
+def _write_delete(
+    store: Store,
+    connector: BaseConnector,
+    source_id: str,
+    entity_id: str,
+) -> str:
+    """Handle the 'delete' action — remove a record."""
+    existing = store.get_entity(entity_id)
+    if existing is None:
+        return f"Entity not found: {entity_id}"
+
+    # Write through to source.
+    connector.write(entity_id, {"action": "delete"})
+
+    # Remove from store.
+    store.delete_entity(entity_id)
+
+    return format_write(action="delete", entity_id=entity_id)

--- a/tests/mcp/test_write.py
+++ b/tests/mcp/test_write.py
@@ -1,0 +1,280 @@
+"""Tests for the MCP write tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from brij.connectors.csv_local import CsvLocalConnector
+from brij.core.store import Store
+from brij.mcp.tools import search, write
+
+
+@pytest.fixture()
+def store() -> Store:
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def clients_csv(tmp_path: Path) -> Path:
+    """CSV fixture with a few rows."""
+    content = (
+        "name,email,role\n"
+        "Alice Johnson,alice@example.com,Engineer\n"
+        "Bob Smith,bob@example.com,Designer\n"
+        "Carol Davis,carol@example.com,Manager\n"
+    )
+    path = tmp_path / "clients.csv"
+    path.write_text(content)
+    return path
+
+
+def _connect_source(csv_path: Path, store: Store) -> str:
+    """Connect a CSV source and store all entities. Returns the source_id."""
+    conn = CsvLocalConnector()
+    conn.authenticate({"path": str(csv_path)})
+
+    discovered = conn.discover()
+    source_id = discovered[0].source_id
+
+    store.add_source(source_id, csv_path.stem, "csv_local")
+
+    for entity in discovered:
+        store.put_entity(entity)
+
+    collection_id = discovered[0].id
+    records = conn.read(collection_id)
+    for record in records:
+        store.put_entity(record)
+
+    return source_id
+
+
+class TestWriteAdd:
+    """Tests for the write tool 'add' action."""
+
+    def test_add_record_appears_in_search(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Add a record via write tool, verify it appears in search."""
+        source_id = _connect_source(clients_csv, store)
+        collection_id = f"collection:{clients_csv.name}"
+
+        result = write(
+            store,
+            action="add",
+            source_id=source_id,
+            collection_id=collection_id,
+            data={"name": "Zara Test", "email": "zara@example.com", "role": "Tester"},
+        )
+
+        assert "Added" in result
+        assert "Zara Test" in result
+
+        # Verify the new record is found by search.
+        search_result = search(store, "Zara")
+        assert "Zara Test" in search_result
+
+    def test_add_record_written_to_csv(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Added record is also written through to the CSV file."""
+        source_id = _connect_source(clients_csv, store)
+        collection_id = f"collection:{clients_csv.name}"
+
+        write(
+            store,
+            action="add",
+            source_id=source_id,
+            collection_id=collection_id,
+            data={"name": "New Person", "email": "new@example.com", "role": "Intern"},
+        )
+
+        csv_content = clients_csv.read_text()
+        assert "New Person" in csv_content
+        assert "new@example.com" in csv_content
+
+    def test_add_requires_collection_id(self, clients_csv: Path, store: Store) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(store, action="add", source_id=source_id, data={"name": "X"})
+        assert "collection_id" in result
+
+
+class TestWriteUpdate:
+    """Tests for the write tool 'update' action."""
+
+    def test_update_field_verified_in_store(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Update a field, verify the change persists in the store."""
+        source_id = _connect_source(clients_csv, store)
+
+        # Alice is row 0.
+        entity_id = f"record:{clients_csv.name}:0"
+
+        result = write(
+            store,
+            action="update",
+            source_id=source_id,
+            entity_id=entity_id,
+            data={"role": "Lead Engineer"},
+        )
+
+        assert "Updated" in result
+
+        # Verify the change in the store.
+        entity = store.get_entity(entity_id)
+        assert entity is not None
+        assert entity.get_signal_value("field:role") == "Lead Engineer"
+
+    def test_update_field_written_to_csv(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Updated field is also written through to the CSV file."""
+        source_id = _connect_source(clients_csv, store)
+        entity_id = f"record:{clients_csv.name}:0"
+
+        write(
+            store,
+            action="update",
+            source_id=source_id,
+            entity_id=entity_id,
+            data={"role": "Lead Engineer"},
+        )
+
+        csv_content = clients_csv.read_text()
+        assert "Lead Engineer" in csv_content
+
+    def test_update_nonexistent_entity(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(
+            store,
+            action="update",
+            source_id=source_id,
+            entity_id="record:clients.csv:999",
+            data={"role": "Ghost"},
+        )
+        assert "not found" in result
+
+    def test_update_requires_entity_id(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(
+            store, action="update", source_id=source_id, data={"role": "X"}
+        )
+        assert "entity_id" in result
+
+
+class TestWriteDelete:
+    """Tests for the write tool 'delete' action."""
+
+    def test_delete_record_gone_from_store(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Delete a record, verify it's gone from the store."""
+        source_id = _connect_source(clients_csv, store)
+
+        # Bob is row 1.
+        entity_id = f"record:{clients_csv.name}:1"
+
+        result = write(
+            store,
+            action="delete",
+            source_id=source_id,
+            entity_id=entity_id,
+        )
+
+        assert "Deleted" in result
+
+        # Verify gone from store.
+        entity = store.get_entity(entity_id)
+        assert entity is None
+
+    def test_delete_record_removed_from_csv(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Deleted record is also removed from the CSV file."""
+        source_id = _connect_source(clients_csv, store)
+        entity_id = f"record:{clients_csv.name}:1"
+
+        write(
+            store,
+            action="delete",
+            source_id=source_id,
+            entity_id=entity_id,
+        )
+
+        csv_content = clients_csv.read_text()
+        assert "Bob Smith" not in csv_content
+
+    def test_delete_nonexistent_entity(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(
+            store,
+            action="delete",
+            source_id=source_id,
+            entity_id="record:clients.csv:999",
+        )
+        assert "not found" in result
+
+    def test_delete_requires_entity_id(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(store, action="delete", source_id=source_id)
+        assert "entity_id" in result
+
+
+class TestWriteCreate:
+    """Tests for the write tool 'create' action."""
+
+    def test_create_collection(
+        self, clients_csv: Path, store: Store, tmp_path: Path
+    ) -> None:
+        """Create a new collection and verify it exists in the store."""
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(
+            store,
+            action="create",
+            source_id=source_id,
+            data={"name": "projects", "fields": ["title", "status", "owner"]},
+        )
+
+        assert "Created" in result
+        assert "projects" in result
+
+        # Collection entity exists in the store.
+        entity = store.get_entity("collection:projects.csv")
+        assert entity is not None
+        assert entity.get_signal_value("name") == "projects.csv"
+
+        # CSV file was created on disk.
+        new_csv = tmp_path / "projects.csv"
+        assert new_csv.exists()
+        assert "title,status,owner" in new_csv.read_text()
+
+
+class TestWriteInvalidAction:
+    """Tests for invalid write actions."""
+
+    def test_invalid_action_returns_error(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        source_id = _connect_source(clients_csv, store)
+
+        result = write(store, action="explode", source_id=source_id)
+        assert "Invalid action" in result


### PR DESCRIPTION
## Summary
- Add `brij_write` MCP tool with four actions: **create** (new collection), **add** (new record), **update** (modify record), **delete** (remove record)
- Implement CSV connector write-through so changes flow back to the original CSV file
- Add response formatting that confirms what changed after each write operation

Closes #18

## Test plan
- [x] Add a record via write tool, verify it appears in search
- [x] Update a field via write tool, verify the change persists in store and CSV
- [x] Delete a record via write tool, verify it's gone from store and CSV
- [x] Create a new collection, verify entity in store and CSV file on disk
- [x] Validate error handling for missing params and invalid actions
- [x] All 182 tests pass, ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)