### PR TITLE
feat: add Google Sheets connector read and sync

### DIFF
--- a/brij/connectors/google_sheets.py
+++ b/brij/connectors/google_sheets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 
 from google.auth.transport.requests import Request
@@ -14,6 +15,7 @@ from googleapiclient.discovery import build
 from brij.connectors.base import (
     AuthenticationError,
     BaseConnector,
+    EntityNotFoundError,
     SyncResult,
 )
 from brij.core.models import Entity, Signal
@@ -71,11 +73,13 @@ class GoogleSheetsConnector(BaseConnector):
 
     def __init__(self) -> None:
         self._service = None
+        self._drive_service = None
         self._creds = None
         self._source_id: str = ""
         self._credentials_path: Path = DEFAULT_CREDENTIALS_PATH
         self._token_path: Path = TOKEN_PATH
         self._spreadsheets: list[dict] | None = None
+        self._last_modified: dict[str, datetime] = {}
 
     def authenticate(self, credentials: dict) -> None:
         """Authenticate with Google Sheets API via OAuth.
@@ -145,11 +149,11 @@ class GoogleSheetsConnector(BaseConnector):
             raise AuthenticationError("authenticate() must be called before discover()")
 
         try:
-            drive_service = build("drive", "v3", credentials=self._creds)
+            self._drive_service = build("drive", "v3", credentials=self._creds)
         except Exception:
-            drive_service = None
+            self._drive_service = None
 
-        spreadsheets = self._list_spreadsheets(drive_service)
+        spreadsheets = self._list_spreadsheets(self._drive_service)
         self._spreadsheets = spreadsheets
 
         entities: list[Entity] = []
@@ -172,6 +176,11 @@ class GoogleSheetsConnector(BaseConnector):
             tab_names = [
                 s.get("properties", {}).get("title", "") for s in sheets
             ]
+
+            if modified_time:
+                self._last_modified[spreadsheet_id] = datetime.fromisoformat(
+                    modified_time.replace("Z", "+00:00")
+                )
 
             collection_id = self.make_entity_id("collection", spreadsheet_id)
             collection_signals = [
@@ -270,21 +279,90 @@ class GoogleSheetsConnector(BaseConnector):
             logger.warning("Failed to list spreadsheets via Drive API")
             return []
 
-    def read(self, entity_id: str) -> list[Signal]:
-        """Read signals for a specific entity.
+    def read(self, entity_id: str) -> list[Entity]:
+        """Read record entities for a collection.
+
+        For a collection entity: reads all rows from all tabs. Each row
+        becomes a record entity with ``field:{column_name}`` signals for
+        every cell value.
 
         Args:
-            entity_id: The ID of the entity to read.
+            entity_id: The ID of the collection entity to read.
 
         Returns:
-            List of signals for the entity.
+            List of record entities with field value signals.
 
         Raises:
             AuthenticationError: If authenticate() has not been called.
+            EntityNotFoundError: If the entity_id is not a known collection.
         """
         if self._service is None:
             raise AuthenticationError("authenticate() must be called before read()")
-        return []
+
+        if not entity_id.startswith("collection:"):
+            raise EntityNotFoundError(f"Unknown entity: {entity_id}")
+
+        spreadsheet_id = entity_id[len("collection:"):]
+
+        try:
+            sheet_meta = (
+                self._service.spreadsheets()
+                .get(spreadsheetId=spreadsheet_id)
+                .execute()
+            )
+        except Exception as exc:
+            raise EntityNotFoundError(
+                f"Failed to fetch spreadsheet {spreadsheet_id}: {exc}"
+            ) from exc
+
+        sheets = sheet_meta.get("sheets", [])
+        entities: list[Entity] = []
+
+        for sheet in sheets:
+            tab_title = sheet.get("properties", {}).get("title", "")
+            range_name = f"'{tab_title}'"
+
+            try:
+                result = (
+                    self._service.spreadsheets()
+                    .values()
+                    .get(spreadsheetId=spreadsheet_id, range=range_name)
+                    .execute()
+                )
+                rows = result.get("values", [])
+            except Exception:
+                logger.warning(
+                    "Failed to read data from %s/%s", spreadsheet_id, tab_title
+                )
+                continue
+
+            if not rows:
+                continue
+
+            headers = rows[0]
+            data_rows = rows[1:]
+
+            for row_idx, row in enumerate(data_rows):
+                record_id = self.make_entity_id(
+                    "record", f"{spreadsheet_id}:{tab_title}:{row_idx}"
+                )
+                signals = []
+                for col_idx, header in enumerate(headers):
+                    value = row[col_idx] if col_idx < len(row) else ""
+                    signals.append(Signal(kind=f"field:{header}", value=value))
+
+                entities.append(
+                    Entity(
+                        id=record_id,
+                        type="record",
+                        source_id=self._source_id,
+                        parent_id=entity_id,
+                        signals=signals,
+                    )
+                )
+
+        logger.info("Read %d records from spreadsheet %s", len(entities), spreadsheet_id)
+        return entities
 
     def write(self, entity_id: str, data: dict) -> bool:
         """Write data to Google Sheets (not yet implemented).
@@ -303,6 +381,8 @@ class GoogleSheetsConnector(BaseConnector):
     def sync(self) -> SyncResult:
         """Check for modified spreadsheets since last discover.
 
+        Uses the Drive API modification timestamp to detect changes.
+
         Returns:
             SyncResult with modified spreadsheet collection IDs.
 
@@ -311,4 +391,26 @@ class GoogleSheetsConnector(BaseConnector):
         """
         if self._service is None:
             raise AuthenticationError("authenticate() must be called before sync()")
-        return SyncResult()
+
+        if not self._last_modified:
+            self.discover()
+
+        spreadsheets = self._list_spreadsheets(self._drive_service)
+        modified: list[str] = []
+
+        for spreadsheet in spreadsheets:
+            spreadsheet_id = spreadsheet["id"]
+            modified_time_str = spreadsheet.get("modifiedTime", "")
+            if not modified_time_str:
+                continue
+
+            current_mtime = datetime.fromisoformat(
+                modified_time_str.replace("Z", "+00:00")
+            )
+            baseline = self._last_modified.get(spreadsheet_id)
+            if baseline is not None and current_mtime > baseline:
+                collection_id = self.make_entity_id("collection", spreadsheet_id)
+                modified.append(collection_id)
+                self._last_modified[spreadsheet_id] = current_mtime
+
+        return SyncResult(modified=modified)

--- a/tests/connectors/test_google_sheets.py
+++ b/tests/connectors/test_google_sheets.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from brij.connectors.base import AuthenticationError
+from brij.connectors.base import AuthenticationError, EntityNotFoundError
 from brij.connectors.google_sheets import GoogleSheetsConnector
 
 # Module path for patching local imports inside authenticate()
@@ -328,3 +328,176 @@ class TestDiscover:
 
         # 1 collection + 5 fields (3 from Sheet1 + 2 from Sheet2)
         assert len(entities) == 6
+
+
+# ---- Read ----
+
+
+class TestRead:
+    def test_read_before_authenticate_raises(self) -> None:
+        conn = GoogleSheetsConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.read("collection:spreadsheet-id-1")
+
+    def test_read_returns_record_entities(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        assert all(e.type == "record" for e in entities)
+
+    def test_read_creates_one_record_per_row(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        # Sheet1 has 3 data rows, Sheet2 has 2 data rows
+        assert len(entities) == 5
+
+    def test_read_records_have_field_signals(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        # First record is from Sheet1 (Alice, 30, true)
+        first = entities[0]
+        assert first.get_signal_value("field:Name") == "Alice"
+        assert first.get_signal_value("field:Age") == "30"
+        assert first.get_signal_value("field:Active") == "true"
+
+    def test_read_records_are_tier_3(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        for entity in entities:
+            assert entity.tier == 3
+
+    def test_read_records_are_children_of_collection(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        for entity in entities:
+            assert entity.parent_id == "collection:spreadsheet-id-1"
+
+    def test_read_records_have_source_id(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        for entity in entities:
+            assert entity.source_id == "google_sheets:user"
+
+    def test_read_includes_all_tabs(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        # Sheet2 records should have Product/Price fields
+        sheet2_records = [e for e in entities if e.get_signal_value("field:Product")]
+        assert len(sheet2_records) == 2
+        assert sheet2_records[0].get_signal_value("field:Product") == "Widget"
+        assert sheet2_records[0].get_signal_value("field:Price") == "9.99"
+
+    def test_read_unknown_entity_raises(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        with pytest.raises(EntityNotFoundError, match="Unknown entity"):
+            authenticated_connector.read("field:something")
+
+    def test_read_record_ids_include_tab_and_row(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        assert entities[0].id == "record:spreadsheet-id-1:Sheet1:0"
+        assert entities[3].id == "record:spreadsheet-id-1:Sheet2:0"
+
+
+# ---- Sync ----
+
+
+class TestSync:
+    def test_sync_before_authenticate_raises(self) -> None:
+        conn = GoogleSheetsConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.sync()
+
+    def test_sync_detects_modified_spreadsheet(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        # Update mock to return a newer modifiedTime
+        updated_drive = MagicMock()
+        updated_drive.files().list().execute.return_value = {
+            "files": [
+                {
+                    "id": "spreadsheet-id-1",
+                    "name": "My Spreadsheet",
+                    "modifiedTime": "2025-02-20T12:00:00Z",
+                },
+            ]
+        }
+        authenticated_connector._drive_service = updated_drive
+
+        result = authenticated_connector.sync()
+        assert "collection:spreadsheet-id-1" in result.modified
+
+    def test_sync_no_changes(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        # Same modifiedTime — no changes
+        authenticated_connector._drive_service = mock_drive_service
+
+        result = authenticated_connector.sync()
+        assert result.modified == []
+
+    def test_sync_updates_baseline_after_detection(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        # First sync: newer timestamp
+        updated_drive = MagicMock()
+        updated_drive.files().list().execute.return_value = {
+            "files": [
+                {
+                    "id": "spreadsheet-id-1",
+                    "name": "My Spreadsheet",
+                    "modifiedTime": "2025-02-20T12:00:00Z",
+                },
+            ]
+        }
+        authenticated_connector._drive_service = updated_drive
+        result1 = authenticated_connector.sync()
+        assert len(result1.modified) == 1
+
+        # Second sync with same timestamp: no changes
+        result2 = authenticated_connector.sync()
+        assert result2.modified == []


### PR DESCRIPTION
## Summary
- Implement `read()` on Google Sheets connector: fetches all rows from all tabs, creating record entities with `field:{column_name}` signals for every cell value
- Implement `sync()` using Drive API modification timestamps to detect changed spreadsheets
- Add 14 new tests covering read (10) and sync (4) behavior

Closes #21

## Test plan
- [x] `read()` returns record entities for all rows across all tabs
- [x] Each record is Tier 3 with field signals for every column
- [x] Records are children of the collection entity
- [x] Unknown entity IDs raise `EntityNotFoundError`
- [x] `sync()` detects modified spreadsheets via timestamp comparison
- [x] `sync()` returns empty when nothing changed
- [x] All 221 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)