### PR TITLE
docs: rewrite README with quickstart and MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,75 @@
 # Brij
 
-An open-source personal data connectivity layer for AI agents.
-
 ![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
 ![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)
 ![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-green)
 
-Brij connects your personal data sources (CSV files, Google Sheets, and more) to AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/). It gives agents structured, searchable access to your data without requiring you to hand over raw files or copy-paste context.
+Brij is an open-source personal data connectivity layer for AI agents. It connects your data sources — CSV files, Google Sheets, and more — to AI agents via the [Model Context Protocol](https://modelcontextprotocol.io/), giving them structured, searchable access without handing over raw files.
 
-## Project Status
-
-Brij is in early alpha. The core data model and storage layer are functional, but there are no connectors or MCP server yet. This is a good time to explore the codebase and contribute.
-
-## Development Setup
+## Install
 
 ```bash
-git clone https://github.com/strouddm/openbrij.git
-cd openbrij
-pip install -e ".[dev]"
+pip install brij
 ```
 
-## Running Tests
+## Quick Start
+
+### Connect a CSV and search it
 
 ```bash
-pytest tests/ -v
+brij connect csv_local --path contacts.csv
+brij search "engineers in San Francisco"
 ```
 
-## Linting
+### Connect Google Sheets and search it
 
 ```bash
-ruff check brij/
-ruff format brij/
+brij connect google_sheets
+# Opens browser for OAuth, then lets you select a spreadsheet
+brij search "Q1 revenue"
 ```
 
-## Architecture
+### Start the MCP server
 
-Brij models all data as **Entities** and **Signals**. An Entity is a node in a data graph (a source, collection, record, or field). Each Entity carries a list of Signals — typed key-value pairs that describe it (name, email, field values, summaries). This two-layer model lets Brij represent data from any source in a uniform way, enabling cross-source search and AI-friendly retrieval without source-specific logic.
+```bash
+brij serve
+```
+
+Add Brij to Claude Desktop by editing `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "brij": {
+      "command": "brij",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Once connected, Claude can discover your data, search across sources, and write back to them.
+
+## How It Works
+
+**Entity/Signal model.** Brij models all data as Entities (source, collection, record, field) and Signals (typed key-value pairs like name, email, or field values). This uniform representation lets it work across any data source without source-specific logic.
+
+**Three MCP tools.** The server exposes `brij_discover` (catalog of connected sources), `brij_search` (natural language search across sources), and `brij_write` (create, add, update, delete records).
+
+**Hybrid search.** Queries run against both semantic embeddings and structured signals, so agents find relevant records whether they match keywords exactly or by meaning.
+
+## CLI Reference
+
+```
+brij connect <connector>   Connect a data source (csv_local, google_sheets)
+brij status                Show connected sources and entity counts
+brij search <query>        Search across connected data
+brij serve                 Start the MCP server
+```
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get involved.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrites README.md with concise documentation (76 lines)
- Adds install, CSV/Google Sheets quickstart, MCP server setup for Claude Desktop
- Documents Entity/Signal model, three MCP tools, and hybrid search
- Adds CLI reference table

Closes #23

## Test plan
- [x] README renders correctly on GitHub
- [x] Under 100 lines
- [x] All CLI commands match actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)