### PR TITLE
feat: improve MCP search limit and discover sample records

### DIFF
--- a/brij/mcp/responses.py
+++ b/brij/mcp/responses.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 # Approximate chars-per-token ratio for budget enforcement.
 _CHARS_PER_TOKEN = 4
-_DEFAULT_TOKEN_BUDGET = 2000
+_DEFAULT_TOKEN_BUDGET = 4000
 _SEARCH_TOKEN_BUDGET = 3000
 
 
@@ -86,6 +86,19 @@ def format_discover(store: Store, token_budget: int = _DEFAULT_TOKEN_BUDGET) -> 
                     else:
                         field_names.append(fname)
                 lines.append(f"      Fields: {', '.join(field_names)}")
+
+            # Sample records (up to 5) so the agent understands the data shape.
+            sample_records = coll_records[:5]
+            if sample_records:
+                sample_count = len(sample_records)
+                total_count = len(coll_records)
+                lines.append(f"      Sample records ({sample_count} of {total_count}):")
+                for rec in sample_records:
+                    field_sigs = [s for s in rec.signals if s.kind.startswith("field:")]
+                    parts = [
+                        f"{s.kind.removeprefix('field:')}: {s.value}" for s in field_sigs
+                    ]
+                    lines.append(f"        - {', '.join(parts)}")
 
             lines.append("")
 

--- a/brij/mcp/server.py
+++ b/brij/mcp/server.py
@@ -48,7 +48,7 @@ def brij_discover() -> str:
 def brij_search(
     query: str,
     sources: list[str] | None = None,
-    limit: int = 5,
+    limit: int = 20,
     offset: int = 0,
 ) -> str:
     """Search connected data sources.
@@ -59,7 +59,7 @@ def brij_search(
     Args:
         query: The search query string.
         sources: Optional list of source IDs to filter results.
-        limit: Maximum number of results to return (default 5).
+        limit: Maximum number of results to return (default 20).
         offset: Number of results to skip for pagination (default 0).
     """
     store = _get_store()

--- a/brij/mcp/tools.py
+++ b/brij/mcp/tools.py
@@ -40,7 +40,7 @@ def search(
     store: Store,
     query: str,
     sources: list[str] | None = None,
-    limit: int = 5,
+    limit: int = 20,
     offset: int = 0,
     search_config: SearchConfig | None = None,
 ) -> str:
@@ -50,7 +50,7 @@ def search(
         store: The Brij data store.
         query: The search query string.
         sources: Optional list of source IDs to filter by.
-        limit: Maximum results to return (default 5).
+        limit: Maximum results to return (default 20).
         offset: Number of results to skip for pagination (default 0).
         search_config: Optional search configuration override.
 

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -96,6 +96,32 @@ class TestDiscover:
         assert "entities" in result
         assert "signals" in result
 
+    def test_summary_includes_sample_records(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Discover should include sample records so the agent sees data shape."""
+        _connect_source(clients_csv, store)
+
+        result = discover(store)
+
+        assert "Sample records" in result
+        assert "Alice" in result or "alice@example.com" in result
+        assert "Bob" in result or "bob@example.com" in result
+
+    def test_sample_records_capped_at_five(
+        self, tmp_path: Path, store: Store
+    ) -> None:
+        """Only up to 5 sample records should appear even with more data."""
+        rows = "\n".join(f"Person{i},p{i}@test.com,Role{i}" for i in range(10))
+        csv_path = tmp_path / "big.csv"
+        csv_path.write_text(f"name,email,role\n{rows}\n")
+
+        _connect_source(csv_path, store)
+
+        result = discover(store)
+
+        assert "5 of 10" in result
+
     def test_response_under_token_budget(
         self, clients_csv: Path, store: Store
     ) -> None:


### PR DESCRIPTION
## Summary
- Increase `brij_search` default limit from 5 to 20 so agents get more results by default
- Add up to 5 sample records per collection in `brij_discover` output — agents now see source name, column names, record count, and actual data samples without needing to search
- Bump discover token budget from 2000 to 4000 to accommodate sample records

## Test plan
- [x] `test_summary_includes_sample_records` — discover output contains sample record values
- [x] `test_sample_records_capped_at_five` — 10-row CSV only shows 5 samples
- [x] All 18 existing MCP tool tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)