### PR TITLE
feat: improve CLI and Google Sheets connector

### DIFF
--- a/brij/cli.py
+++ b/brij/cli.py
@@ -33,19 +33,37 @@ def _get_store(config: Config | None = None) -> Store:
     return Store(config.db_path)
 
 
-@click.group()
+@click.group(context_settings={"max_content_width": 120})
 @click.option("--verbose", "-v", is_flag=True, help="Enable debug logging.")
-def main(verbose: bool) -> None:
+@click.pass_context
+def main(ctx: click.Context, verbose: bool) -> None:
     """Brij — personal data connectivity layer for AI agents."""
-    level = logging.DEBUG if verbose else logging.WARNING
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(levelname)s: %(message)s")
+
+
+def _setup_logging(ctx: click.Context, verbose: bool) -> None:
+    """Enable debug logging if --verbose passed to this command or the parent group."""
+    parent = ctx.parent
+    parent_verbose = (
+        parent.obj.get("verbose", False) if parent and parent.obj else False
+    )
+    if verbose or parent_verbose:
+        logging.basicConfig(level=logging.DEBUG, format="%(levelname)s: %(message)s", force=True)
+    elif not logging.root.handlers:
+        logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 
 
 @main.command()
 @click.argument("connector_name")
-@click.option("--path", required=True, help="Path to the data source (e.g. CSV file).")
-def connect(connector_name: str, path: str) -> None:
+@click.option("--path", default=None, help="Path to the data source (e.g. CSV file).")
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug logging.")
+@click.pass_context
+def connect(ctx: click.Context, connector_name: str, path: str | None, verbose: bool) -> None:
     """Authenticate a connector and discover its data."""
+    _setup_logging(ctx, verbose)
     _ensure_builtins_registered()
     discover_connectors()
     connector_cls = get_connector(connector_name)
@@ -53,14 +71,42 @@ def connect(connector_name: str, path: str) -> None:
         click.echo(f"Unknown connector: {connector_name}", err=True)
         sys.exit(1)
 
+    # Build credentials dict based on connector type.
+    _OAUTH_CONNECTORS = {"google_sheets"}
+    if path is not None:
+        credentials: dict = {"path": path}
+    elif connector_name in _OAUTH_CONNECTORS:
+        credentials = {}
+    else:
+        click.echo(f"--path is required for connector: {connector_name}", err=True)
+        sys.exit(1)
+
     connector = connector_cls()
     try:
-        connector.authenticate({"path": path})
+        connector.authenticate(credentials)
     except Exception as exc:
         click.echo(f"Authentication failed: {exc}", err=True)
         sys.exit(1)
 
-    entities = connector.discover()
+    # For Google Sheets, let the user pick a single spreadsheet.
+    selected_spreadsheet_id = None
+    if connector_name == "google_sheets":
+        spreadsheets = connector.list_spreadsheets()
+        if not spreadsheets:
+            click.echo("No spreadsheets found.")
+            return
+        click.echo("Available spreadsheets:")
+        for i, s in enumerate(spreadsheets, 1):
+            click.echo(f"  {i}. {s['name']}")
+        choice = click.prompt(
+            "Select a spreadsheet", type=click.IntRange(1, len(spreadsheets))
+        )
+        selected_spreadsheet_id = spreadsheets[choice - 1]["id"]
+
+    if selected_spreadsheet_id is not None:
+        entities = connector.discover(spreadsheet_id=selected_spreadsheet_id)
+    else:
+        entities = connector.discover()
     if not entities:
         click.echo("No entities discovered.")
         return
@@ -70,7 +116,7 @@ def connect(connector_name: str, path: str) -> None:
     store = _get_store(config)
     try:
         source_id = entities[0].source_id
-        store.add_source(source_id, source_id, connector_name, json.dumps({"path": path}))
+        store.add_source(source_id, source_id, connector_name, json.dumps(credentials))
 
         for entity in entities:
             store.put_entity(entity)
@@ -94,8 +140,11 @@ def connect(connector_name: str, path: str) -> None:
 
 
 @main.command()
-def status() -> None:
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug logging.")
+@click.pass_context
+def status(ctx: click.Context, verbose: bool) -> None:
     """Show connected sources, entity counts, and index coverage."""
+    _setup_logging(ctx, verbose)
     config = Config.load()
     if not config.db_path.exists():
         click.echo("No database found. Connect a source first with: brij connect")
@@ -136,8 +185,17 @@ def status() -> None:
 @click.argument("query")
 @click.option("--source", "-s", multiple=True, help="Filter by source ID.")
 @click.option("--limit", "-n", default=5, help="Max results (default 5).")
-def search(query: str, source: tuple[str, ...], limit: int) -> None:
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug logging.")
+@click.pass_context
+def search(
+    ctx: click.Context,
+    query: str,
+    source: tuple[str, ...],
+    limit: int,
+    verbose: bool,
+) -> None:
     """Search connected data sources."""
+    _setup_logging(ctx, verbose)
     config = Config.load()
     if not config.db_path.exists():
         click.echo("No database found. Connect a source first with: brij connect")

--- a/brij/connectors/google_sheets.py
+++ b/brij/connectors/google_sheets.py
@@ -26,7 +26,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_CREDENTIALS_PATH = Path.home() / ".brij" / "google-credentials.json"
 TOKEN_PATH = Path.home() / ".brij" / "google-sheets-token.json"
 
-SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive.readonly",
+]
 
 # Number of rows sampled per tab for column type inference.
 _TYPE_SAMPLE_ROWS = 100
@@ -67,6 +70,42 @@ def _is_float(value: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _find_header_row(rows: list[list[str]]) -> tuple[list[str], list[list[str]]]:
+    """Locate the header row by skipping leading empty rows.
+
+    Many shared Google Sheets have a blank or title-only first row
+    (banners, merged cells, etc.).  This scans forward until it finds
+    a row with at least two non-empty cells — that row is treated as
+    the header.  Everything after it is data.
+
+    Returns:
+        (headers, data_rows) where *headers* may be empty if no
+        suitable row is found.
+    """
+    for idx, row in enumerate(rows):
+        non_empty = [c for c in row if c.strip()]
+        if len(non_empty) >= 2:
+            return row, rows[idx + 1:]
+    return [], rows
+
+
+def _dedupe_headers(headers: list[str]) -> list[str]:
+    """Make duplicate or empty column headers unique.
+
+    Google Sheets allows duplicate column names and blank headers.
+    This appends ``_2``, ``_3``, … to repeats so every header maps
+    to a distinct ``field:{name}`` signal kind.
+    """
+    seen: dict[str, int] = {}
+    result: list[str] = []
+    for h in headers:
+        name = h.strip() if h.strip() else "unnamed"
+        count = seen.get(name, 0) + 1
+        seen[name] = count
+        result.append(name if count == 1 else f"{name}_{count}")
+    return result
 
 
 class GoogleSheetsConnector(BaseConnector):
@@ -133,12 +172,38 @@ class GoogleSheetsConnector(BaseConnector):
         self._source_id = "google_sheets:user"
         logger.info("Authenticated with Google Sheets API")
 
-    def discover(self) -> list[Entity]:
-        """List all spreadsheets accessible to the user.
+    def list_spreadsheets(self) -> list[dict]:
+        """Return available spreadsheets without discovering their contents.
 
-        For each spreadsheet, creates a collection entity with sheet name,
-        tab names, column headers per tab, and last modified date.
-        Field entities are created for each column with name and inferred type.
+        Each dict has ``id``, ``name``, and ``modifiedTime`` keys.
+
+        Raises:
+            AuthenticationError: If authenticate() has not been called.
+        """
+        if self._service is None:
+            raise AuthenticationError(
+                "authenticate() must be called before list_spreadsheets()"
+            )
+
+        self._ensure_drive_service()
+        return self._list_spreadsheets(self._drive_service)
+
+    def _ensure_drive_service(self) -> None:
+        """Build the Drive service if it hasn't been created yet."""
+        if self._drive_service is None:
+            try:
+                self._drive_service = build("drive", "v3", credentials=self._creds)
+            except Exception:
+                self._drive_service = None
+
+    def discover(self, spreadsheet_id: str | None = None) -> list[Entity]:
+        """Discover spreadsheet entities.
+
+        When *spreadsheet_id* is provided, only that spreadsheet is
+        discovered.  Otherwise all accessible spreadsheets are discovered.
+
+        Args:
+            spreadsheet_id: Optional ID of a single spreadsheet to discover.
 
         Returns:
             List of collection and field entities.
@@ -149,12 +214,12 @@ class GoogleSheetsConnector(BaseConnector):
         if self._service is None:
             raise AuthenticationError("authenticate() must be called before discover()")
 
-        try:
-            self._drive_service = build("drive", "v3", credentials=self._creds)
-        except Exception:
-            self._drive_service = None
+        self._ensure_drive_service()
 
-        spreadsheets = self._list_spreadsheets(self._drive_service)
+        if spreadsheet_id is not None:
+            spreadsheets = [{"id": spreadsheet_id, "name": "", "modifiedTime": ""}]
+        else:
+            spreadsheets = self._list_spreadsheets(self._drive_service)
         self._spreadsheets = spreadsheets
 
         entities: list[Entity] = []
@@ -221,8 +286,7 @@ class GoogleSheetsConnector(BaseConnector):
                 if not rows:
                     continue
 
-                headers = rows[0]
-                data_rows = rows[1:]
+                headers, data_rows = _find_header_row(rows)
 
                 for col_idx, header in enumerate(headers):
                     if not header.strip():
@@ -340,8 +404,15 @@ class GoogleSheetsConnector(BaseConnector):
             if not rows:
                 continue
 
-            headers = rows[0]
-            data_rows = rows[1:]
+            raw_headers, data_rows = _find_header_row(rows)
+            headers = _dedupe_headers(raw_headers)
+            logger.debug(
+                "Tab '%s': %d headers %s, %d data rows",
+                tab_title,
+                len(headers),
+                headers,
+                len(data_rows),
+            )
 
             for row_idx, row in enumerate(data_rows):
                 record_id = self.make_entity_id(
@@ -349,9 +420,17 @@ class GoogleSheetsConnector(BaseConnector):
                 )
                 signals = []
                 for col_idx, header in enumerate(headers):
-                    value = row[col_idx] if col_idx < len(row) else ""
-                    signals.append(Signal(kind=f"field:{header}", value=value))
+                    raw = row[col_idx] if col_idx < len(row) else ""
+                    signals.append(
+                        Signal(kind=f"field:{header}", value=str(raw))
+                    )
 
+                logger.debug(
+                    "Record %s:%d — %d signals",
+                    tab_title,
+                    row_idx,
+                    len(signals),
+                )
                 entities.append(
                     Entity(
                         id=record_id,

--- a/tests/connectors/test_google_sheets.py
+++ b/tests/connectors/test_google_sheets.py
@@ -42,7 +42,10 @@ def token_file(tmp_path: Path) -> Path:
         "token_uri": "https://oauth2.googleapis.com/token",
         "client_id": "test-client-id.apps.googleusercontent.com",
         "client_secret": "test-client-secret",
-        "scopes": ["https://www.googleapis.com/auth/spreadsheets"],
+        "scopes": [
+            "https://www.googleapis.com/auth/spreadsheets",
+            "https://www.googleapis.com/auth/drive.readonly",
+        ],
     }
     path = tmp_path / "google-sheets-token.json"
     path.write_text(json.dumps(token))
@@ -189,6 +192,37 @@ class TestAuthenticate:
             )
 
 
+# ---- List Spreadsheets ----
+
+
+class TestListSpreadsheets:
+    def test_list_before_authenticate_raises(self) -> None:
+        conn = GoogleSheetsConnector()
+        with pytest.raises(AuthenticationError, match="authenticate"):
+            conn.list_spreadsheets()
+
+    def test_list_returns_spreadsheets(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            result = authenticated_connector.list_spreadsheets()
+
+        assert len(result) == 1
+        assert result[0]["id"] == "spreadsheet-id-1"
+        assert result[0]["name"] == "My Spreadsheet"
+
+    def test_list_empty(
+        self, authenticated_connector: GoogleSheetsConnector
+    ) -> None:
+        empty_drive = MagicMock()
+        empty_drive.files().list().execute.return_value = {"files": []}
+
+        with patch(f"{_MOD}.build", return_value=empty_drive):
+            result = authenticated_connector.list_spreadsheets()
+
+        assert result == []
+
+
 # ---- Discover ----
 
 
@@ -329,6 +363,21 @@ class TestDiscover:
         # 1 collection + 5 fields (3 from Sheet1 + 2 from Sheet2)
         assert len(entities) == 6
 
+    def test_discover_single_spreadsheet(
+        self, authenticated_connector: GoogleSheetsConnector
+    ) -> None:
+        """discover(spreadsheet_id=...) should only index that spreadsheet."""
+        entities = authenticated_connector.discover(
+            spreadsheet_id="spreadsheet-id-1"
+        )
+
+        collections = [e for e in entities if e.type == "collection"]
+        assert len(collections) == 1
+        assert collections[0].get_signal_value("spreadsheet_id") == "spreadsheet-id-1"
+
+        fields = [e for e in entities if e.type == "field"]
+        assert len(fields) == 5
+
 
 # ---- Read ----
 
@@ -432,6 +481,123 @@ class TestRead:
         entities = authenticated_connector.read("collection:spreadsheet-id-1")
         assert entities[0].id == "record:spreadsheet-id-1:Sheet1:0"
         assert entities[3].id == "record:spreadsheet-id-1:Sheet2:0"
+
+    def test_read_all_records_have_signals(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock
+    ) -> None:
+        """Every record must carry a field signal for every column in its tab."""
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            authenticated_connector.discover()
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        # Sheet1 rows have 3 columns, Sheet2 rows have 2 columns
+        for entity in entities:
+            assert len(entity.signals) > 0, f"Record {entity.id} has no signals"
+            for signal in entity.signals:
+                assert signal.kind.startswith("field:"), (
+                    f"Unexpected signal kind: {signal.kind}"
+                )
+
+        # Sheet1: 3 rows × 3 columns = 9 signals; Sheet2: 2 rows × 2 columns = 4
+        total_signals = sum(len(e.signals) for e in entities)
+        assert total_signals == 13
+
+    def test_read_signals_survive_store_roundtrip(
+        self, authenticated_connector: GoogleSheetsConnector, mock_drive_service: MagicMock,
+        tmp_path,
+    ) -> None:
+        """Signals must persist through put_entity → get_entity in the Store."""
+        from brij.core.store import Store
+
+        with patch(f"{_MOD}.build", return_value=mock_drive_service):
+            discovered = authenticated_connector.discover()
+
+        records = authenticated_connector.read("collection:spreadsheet-id-1")
+
+        store = Store(tmp_path / "test.db")
+        try:
+            store.add_source("google_sheets:user", "test", "google_sheets")
+            for entity in discovered:
+                store.put_entity(entity)
+            for record in records:
+                store.put_entity(record)
+
+            total_signals = store.count_signals()
+            total_entities = store.count_entities()
+
+            # 1 collection (5 signals) + 5 fields (3 each = 15) + 5 records
+            # Sheet1 records: 3 × 3 = 9 signals, Sheet2 records: 2 × 2 = 4 signals
+            assert total_entities == 11  # 1 + 5 + 5
+            assert total_signals == 5 + 15 + 9 + 4  # = 33
+
+            # Verify a record can be retrieved with its signals
+            first = store.get_entity(records[0].id)
+            assert first is not None
+            assert first.get_signal_value("field:Name") == "Alice"
+            assert first.get_signal_value("field:Age") == "30"
+            assert first.get_signal_value("field:Active") == "true"
+        finally:
+            store.close()
+
+    def test_read_dedupe_headers(
+        self, authenticated_connector: GoogleSheetsConnector
+    ) -> None:
+        """Duplicate column names get suffixed so signals are distinct."""
+        service = authenticated_connector._service
+
+        service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"title": "Dupes"}}]
+        }
+
+        def dupes_values(spreadsheetId, range):
+            mock = MagicMock()
+            mock.execute.return_value = {
+                "values": [
+                    ["Name", "Name", ""],
+                    ["Alice", "Smith", "extra"],
+                ]
+            }
+            return mock
+
+        service.spreadsheets().values().get.side_effect = dupes_values
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        assert len(entities) == 1
+        rec = entities[0]
+        assert rec.get_signal_value("field:Name") == "Alice"
+        assert rec.get_signal_value("field:Name_2") == "Smith"
+        assert rec.get_signal_value("field:unnamed") == "extra"
+
+    def test_read_skips_empty_leading_rows(
+        self, authenticated_connector: GoogleSheetsConnector
+    ) -> None:
+        """Sheets with blank/title rows before the header should still work."""
+        service = authenticated_connector._service
+
+        service.spreadsheets().get().execute.return_value = {
+            "sheets": [{"properties": {"title": "Banner"}}]
+        }
+
+        def banner_values(spreadsheetId, range):
+            mock = MagicMock()
+            mock.execute.return_value = {
+                "values": [
+                    [],
+                    ["Title banner only"],
+                    ["Name", "Role", "Location"],
+                    ["Alice", "Eng", "NYC"],
+                    ["Bob", "PM", "LA"],
+                ]
+            }
+            return mock
+
+        service.spreadsheets().values().get.side_effect = banner_values
+
+        entities = authenticated_connector.read("collection:spreadsheet-id-1")
+        assert len(entities) == 2
+        assert entities[0].get_signal_value("field:Name") == "Alice"
+        assert entities[0].get_signal_value("field:Role") == "Eng"
+        assert entities[1].get_signal_value("field:Location") == "LA"
 
 
 # ---- Sync ----

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -70,6 +70,97 @@ class TestConnect:
 
         assert result.exit_code != 0
         assert "Authentication failed" in result.output
+
+    def test_connect_csv_without_path_errors(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        with _patch_config(config):
+            result = runner.invoke(main, ["connect", "csv_local"])
+
+        assert result.exit_code != 0
+        assert "--path is required" in result.output
+
+    def test_connect_google_sheets_without_path(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        """google_sheets should use OAuth and prompt for spreadsheet selection."""
+        mock_connector = MagicMock()
+        mock_connector.list_spreadsheets.return_value = [
+            {"id": "ss1", "name": "Budget", "modifiedTime": ""},
+            {"id": "ss2", "name": "Contacts", "modifiedTime": ""},
+        ]
+        mock_connector.discover.return_value = []
+
+        with _patch_config(config), patch(
+            "brij.cli.get_connector", return_value=lambda: mock_connector
+        ):
+            result = runner.invoke(main, ["connect", "google_sheets"], input="1\n")
+
+        assert result.exit_code == 0
+        assert "Budget" in result.output
+        assert "Contacts" in result.output
+        mock_connector.authenticate.assert_called_once_with({})
+        mock_connector.discover.assert_called_once_with(spreadsheet_id="ss1")
+
+    def test_connect_google_sheets_selects_second(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        """User selects the second spreadsheet from the list."""
+        mock_connector = MagicMock()
+        mock_connector.list_spreadsheets.return_value = [
+            {"id": "ss1", "name": "Budget", "modifiedTime": ""},
+            {"id": "ss2", "name": "Contacts", "modifiedTime": ""},
+        ]
+        mock_connector.discover.return_value = []
+
+        with _patch_config(config), patch(
+            "brij.cli.get_connector", return_value=lambda: mock_connector
+        ):
+            result = runner.invoke(main, ["connect", "google_sheets"], input="2\n")
+
+        assert result.exit_code == 0
+        mock_connector.discover.assert_called_once_with(spreadsheet_id="ss2")
+
+    def test_connect_google_sheets_no_spreadsheets(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        """When no spreadsheets are found, exit early."""
+        mock_connector = MagicMock()
+        mock_connector.list_spreadsheets.return_value = []
+
+        with _patch_config(config), patch(
+            "brij.cli.get_connector", return_value=lambda: mock_connector
+        ):
+            result = runner.invoke(main, ["connect", "google_sheets"])
+
+        assert result.exit_code == 0
+        assert "No spreadsheets found" in result.output
+        mock_connector.discover.assert_not_called()
+
+    def test_connect_google_sheets_with_path(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        """google_sheets with --path should still prompt for selection."""
+        mock_connector = MagicMock()
+        mock_connector.list_spreadsheets.return_value = [
+            {"id": "ss1", "name": "Budget", "modifiedTime": ""},
+        ]
+        mock_connector.discover.return_value = []
+
+        with _patch_config(config), patch(
+            "brij.cli.get_connector", return_value=lambda: mock_connector
+        ):
+            result = runner.invoke(
+                main,
+                ["connect", "google_sheets", "--path", "/tmp/creds.json"],
+                input="1\n",
+            )
+
+        assert result.exit_code == 0
+        mock_connector.authenticate.assert_called_once_with(
+            {"path": "/tmp/creds.json"}
+        )
+        mock_connector.discover.assert_called_once_with(spreadsheet_id="ss1")
 
 
 class TestStatus:


### PR DESCRIPTION
## Summary
- **CLI**: `--path` now optional for OAuth connectors (Google Sheets), interactive spreadsheet selection prompt, per-command `--verbose` flag propagation
- **Google Sheets connector**: new `list_spreadsheets()` method, `discover(spreadsheet_id=...)` for single-spreadsheet discovery, `_find_header_row()` skips blank/banner rows, `_dedupe_headers()` handles duplicate column names, added `drive.readonly` scope
- **Tests**: 5 new CLI tests (path-optional, spreadsheet selection, empty list), 5 new connector tests (list_spreadsheets, dedupe headers, banner rows, store roundtrip, signal coverage)

## Test plan
- [x] 14 CLI tests pass (5 new)
- [x] 54 Google Sheets connector tests pass (5 new)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)