### PR TITLE
feat: add bulk retrieve to search tool

### DIFF
--- a/brij/mcp/server.py
+++ b/brij/mcp/server.py
@@ -50,21 +50,29 @@ def brij_search(
     sources: list[str] | None = None,
     limit: int = 20,
     offset: int = 0,
+    browse: bool = False,
 ) -> str:
     """Search connected data sources.
 
     Returns natural language formatted results with source attribution
     and key field values for each match.
 
+    For bulk retrieval (aggregation, summaries, counts), pass query="*"
+    or browse=True to return all records from the specified sources,
+    paginated at 50 per page.
+
     Args:
-        query: The search query string.
+        query: The search query string. Use "*" for bulk retrieval.
         sources: Optional list of source IDs to filter results.
         limit: Maximum number of results to return (default 20).
         offset: Number of results to skip for pagination (default 0).
+        browse: If True, return all records (like query="*").
     """
     store = _get_store()
     try:
-        return search(store, query, sources=sources, limit=limit, offset=offset)
+        return search(
+            store, query, sources=sources, limit=limit, offset=offset, browse=browse,
+        )
     finally:
         store.close()
 

--- a/brij/mcp/tools.py
+++ b/brij/mcp/tools.py
@@ -36,6 +36,43 @@ def discover(store: Store) -> str:
     return result
 
 
+_BROWSE_DEFAULT_LIMIT = 50
+
+
+def _bulk_retrieve(
+    store: Store,
+    sources: list[str] | None,
+    limit: int,
+    offset: int,
+) -> str:
+    """Return all records for the given sources, paginated.
+
+    Args:
+        store: The Brij data store.
+        sources: Source IDs to retrieve from. If None, retrieves from all.
+        limit: Page size (default 50 for bulk).
+        offset: Number of records to skip.
+
+    Returns:
+        Plain-text formatted results.
+    """
+    all_records = store.get_entities_by_type("record")
+    if sources:
+        all_records = [r for r in all_records if r.source_id in set(sources)]
+
+    total_count = len(all_records)
+    paged = all_records[offset:offset + limit]
+
+    return format_search(
+        query="*",
+        results=paged,
+        total_count=total_count,
+        offset=offset,
+        limit=limit,
+        store=store,
+    )
+
+
 def search(
     store: Store,
     query: str,
@@ -43,20 +80,37 @@ def search(
     limit: int = 20,
     offset: int = 0,
     search_config: SearchConfig | None = None,
+    browse: bool = False,
 ) -> str:
     """Search connected data sources and return formatted results.
 
+    When *browse* is True or *query* is ``"*"``, returns all records
+    from the specified sources paginated at 50 per page (bulk retrieve).
+
     Args:
         store: The Brij data store.
-        query: The search query string.
+        query: The search query string. Use ``"*"`` for bulk retrieval.
         sources: Optional list of source IDs to filter by.
         limit: Maximum results to return (default 20).
         offset: Number of results to skip for pagination (default 0).
         search_config: Optional search configuration override.
+        browse: If True, return all records (like query="*").
 
     Returns:
         Plain-text formatted search results.
     """
+    is_bulk = browse or (query.strip() == "*")
+
+    if is_bulk:
+        bulk_limit = min(limit, _BROWSE_DEFAULT_LIMIT) if limit != 20 else _BROWSE_DEFAULT_LIMIT
+        logger.info(
+            "Running bulk retrieve: sources=%r, limit=%d, offset=%d",
+            sources, bulk_limit, offset,
+        )
+        result = _bulk_retrieve(store, sources, bulk_limit, offset)
+        logger.debug("Bulk retrieve returned %d characters", len(result))
+        return result
+
     logger.info("Running search tool: query=%r, sources=%r, limit=%d, offset=%d",
                 query, sources, limit, offset)
 

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -268,3 +268,84 @@ class TestSearch:
 
         assert "contacts" in result
         assert "projects" not in result.lower() or "Project" not in result
+
+
+class TestBulkRetrieve:
+    """Tests for bulk retrieval via query='*' and browse=True."""
+
+    def test_star_query_returns_all_records(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """query='*' returns all records without keyword matching."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "*")
+
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "Carol" in result
+
+    def test_browse_flag_returns_all_records(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """browse=True returns all records regardless of query."""
+        _connect_source(clients_csv, store)
+
+        result = search(store, "ignored", browse=True)
+
+        assert "Alice" in result
+        assert "Bob" in result
+        assert "Carol" in result
+
+    def test_bulk_pagination(
+        self, clients_csv: Path, store: Store
+    ) -> None:
+        """Bulk retrieve supports offset/limit pagination."""
+        _connect_source(clients_csv, store)
+
+        page1 = search(store, "*", limit=2, offset=0)
+        page2 = search(store, "*", limit=2, offset=2)
+
+        assert "1." in page1
+        assert "2." in page1
+        assert "3." in page2
+
+    def test_bulk_default_limit_is_50(
+        self, tmp_path: Path, store: Store
+    ) -> None:
+        """Default bulk page size is 50, not 20."""
+        rows = "\n".join(f"Person{i},p{i}@test.com" for i in range(60))
+        csv_path = tmp_path / "big.csv"
+        csv_path.write_text(f"name,email\n{rows}\n")
+
+        _connect_source(csv_path, store)
+
+        result = search(store, "*")
+
+        # Should show 50 results, with 10 more available.
+        assert "50" in result
+        assert "10 more" in result
+
+    def test_bulk_source_filter(
+        self, tmp_path: Path, store: Store
+    ) -> None:
+        """Bulk retrieve respects source filter."""
+        csv1 = tmp_path / "contacts.csv"
+        csv1.write_text("name,phone\nAlice,555-1234\n")
+
+        csv2 = tmp_path / "projects.csv"
+        csv2.write_text("name,status\nBob Project,Active\n")
+
+        source1 = _connect_source(csv1, store)
+        _connect_source(csv2, store)
+
+        result = search(store, "*", sources=[source1])
+
+        assert "Alice" in result
+        assert "Bob" not in result
+
+    def test_bulk_empty_store(self, store: Store) -> None:
+        """Bulk retrieve with no records returns helpful message."""
+        result = search(store, "*")
+
+        assert "No results" in result


### PR DESCRIPTION
## Summary
- `query="*"` or `browse=True` triggers bulk retrieval — returns all records paginated at 50/page
- Agents can now do aggregation tasks (counts, histograms, summaries) without guessing keywords
- Source filtering works with bulk retrieve
- Existing search behavior unchanged for normal queries

Closes #44

## Test plan
- [x] `test_star_query_returns_all_records` — query="*" returns all 3 records
- [x] `test_browse_flag_returns_all_records` — browse=True ignores query text
- [x] `test_bulk_pagination` — offset/limit pagination works
- [x] `test_bulk_default_limit_is_50` — 60 records → shows 50, "10 more available"
- [x] `test_bulk_source_filter` — only returns records from specified source
- [x] `test_bulk_empty_store` — returns "No results" message
- [x] All 18 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)