### PR TITLE
feat: index-based semantic search via FAISS ANN

### DIFF
--- a/brij/search/ann_index.py
+++ b/brij/search/ann_index.py
@@ -1,0 +1,139 @@
+"""Approximate nearest neighbor index for semantic search.
+
+Uses FAISS when available for fast ANN search. Falls back to brute-force
+cosine similarity when FAISS is not installed, keeping the zero-dependency
+path working.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+try:
+    import faiss
+
+    FAISS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    FAISS_AVAILABLE = False
+
+# Dimension for all-MiniLM-L6-v2 embeddings.
+_DEFAULT_DIM = 384
+
+
+class ANNIndex:
+    """Approximate nearest neighbor index backed by FAISS or brute-force fallback.
+
+    The index maps integer positions to entity IDs. Call ``add`` to insert
+    vectors, then ``search`` to find the nearest neighbors for a query vector.
+    """
+
+    def __init__(self, dimension: int = _DEFAULT_DIM) -> None:
+        self._dimension = dimension
+        self._entity_ids: list[str] = []
+
+        if FAISS_AVAILABLE:
+            self._index: faiss.IndexFlatIP | None = faiss.IndexFlatIP(dimension)
+            logger.debug("Created FAISS IndexFlatIP (dim=%d)", dimension)
+        else:
+            self._index = None
+            self._vectors: list[np.ndarray] = []
+            logger.debug("FAISS not available, using brute-force fallback (dim=%d)", dimension)
+
+    @property
+    def size(self) -> int:
+        """Return the number of vectors in the index."""
+        return len(self._entity_ids)
+
+    def add(self, entity_id: str, vector_bytes: bytes) -> None:
+        """Add a single vector to the index.
+
+        Args:
+            entity_id: The entity this vector belongs to.
+            vector_bytes: Serialized float32 numpy array.
+        """
+        vec = np.frombuffer(vector_bytes, dtype=np.float32).copy()
+        # Normalize for inner-product similarity (equivalent to cosine on unit vectors).
+        norm = np.linalg.norm(vec)
+        if norm > 0:
+            vec = vec / norm
+
+        self._entity_ids.append(entity_id)
+
+        if self._index is not None:
+            self._index.add(vec.reshape(1, -1))
+        else:
+            self._vectors.append(vec)
+
+    def add_bulk(self, entity_ids: list[str], vectors_bytes: list[bytes]) -> None:
+        """Add multiple vectors at once (more efficient for FAISS).
+
+        Args:
+            entity_ids: Entity IDs corresponding to each vector.
+            vectors_bytes: Serialized float32 numpy arrays.
+        """
+        if not entity_ids:
+            return
+
+        vecs = np.array(
+            [np.frombuffer(v, dtype=np.float32) for v in vectors_bytes],
+            dtype=np.float32,
+        )
+        # L2-normalize each row for cosine similarity via inner product.
+        norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+        norms[norms == 0] = 1.0
+        vecs = vecs / norms
+
+        self._entity_ids.extend(entity_ids)
+
+        if self._index is not None:
+            self._index.add(vecs)
+        else:
+            for vec in vecs:
+                self._vectors.append(vec)
+
+    def search(self, query_bytes: bytes, k: int = 10) -> list[tuple[str, float]]:
+        """Find the k nearest neighbors.
+
+        Args:
+            query_bytes: Serialized float32 query vector.
+            k: Number of results to return.
+
+        Returns:
+            List of (entity_id, similarity_score) tuples, highest first.
+        """
+        if self.size == 0:
+            return []
+
+        query = np.frombuffer(query_bytes, dtype=np.float32).copy()
+        norm = np.linalg.norm(query)
+        if norm > 0:
+            query = query / norm
+
+        k = min(k, self.size)
+
+        if self._index is not None:
+            scores, indices = self._index.search(query.reshape(1, -1), k)
+            results: list[tuple[str, float]] = []
+            for score, idx in zip(scores[0], indices[0]):
+                if idx >= 0:
+                    results.append((self._entity_ids[idx], float(score)))
+            return results
+        else:
+            return self._brute_force_search(query, k)
+
+    def _brute_force_search(
+        self, query: np.ndarray, k: int
+    ) -> list[tuple[str, float]]:
+        """Fallback brute-force inner-product search."""
+        mat = np.array(self._vectors, dtype=np.float32)
+        scores = mat @ query
+        top_k = np.argsort(scores)[::-1][:k]
+        return [(self._entity_ids[i], float(scores[i])) for i in top_k]

--- a/brij/search/engine.py
+++ b/brij/search/engine.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from brij.core.models import Entity
+from brij.search.ann_index import ANNIndex
 
 if TYPE_CHECKING:
     from brij.config import SearchConfig
@@ -136,7 +137,12 @@ class SearchEngine:
         sources: list[str] | None,
         limit: int,
     ) -> dict[str, float]:
-        """Embed the query and compute cosine similarity against stored embeddings."""
+        """Embed the query and find nearest neighbors via ANN index.
+
+        Builds an ANNIndex from stored embeddings and uses it to find
+        the top matches. Uses FAISS when available, otherwise falls back
+        to brute-force inner-product search.
+        """
         assert self._embedding_engine is not None
         query_vector = self._embedding_engine.embed(query)
 
@@ -150,12 +156,17 @@ class SearchEngine:
         if not all_embeddings:
             return {}
 
+        index = ANNIndex()
+        entity_ids = [emb["entity_id"] for emb in all_embeddings]
+        vectors = [emb["vector"] for emb in all_embeddings]
+        index.add_bulk(entity_ids, vectors)
+
+        results = index.search(query_vector, k=limit)
+
         scored: dict[str, float] = {}
-        for emb in all_embeddings:
-            sim = _cosine_similarity(query_vector, emb["vector"])
-            eid = emb["entity_id"]
-            if eid not in scored or sim > scored[eid]:
-                scored[eid] = sim
+        for eid, score in results:
+            if eid not in scored or score > scored[eid]:
+                scored[eid] = score
 
         return scored
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 brij = "brij.cli:main"
 
 [project.optional-dependencies]
+ann = [
+    "faiss-cpu>=1.7",
+]
 dev = [
     "pytest>=7.0",
     "ruff>=0.4",

--- a/tests/search/test_ann_index.py
+++ b/tests/search/test_ann_index.py
@@ -1,0 +1,177 @@
+"""Tests for approximate nearest neighbor index."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brij.config import SearchConfig
+from brij.connectors.csv_local import CsvLocalConnector
+from brij.core.store import Store
+from brij.search.ann_index import FAISS_AVAILABLE, ANNIndex
+from brij.search.embeddings import EmbeddingEngine
+from brij.search.engine import SearchEngine
+
+
+def _random_vector(dim: int = 384, seed: int | None = None) -> bytes:
+    """Generate a random float32 vector as bytes."""
+    rng = np.random.RandomState(seed)
+    vec = rng.randn(dim).astype(np.float32)
+    return vec.tobytes()
+
+
+def _known_vector(value: float, dim: int = 384) -> bytes:
+    """Generate a constant-valued float32 vector as bytes."""
+    vec = np.full(dim, value, dtype=np.float32)
+    return vec.tobytes()
+
+
+class TestANNIndexBasics:
+    """Core index operations."""
+
+    def test_empty_index_returns_no_results(self) -> None:
+        index = ANNIndex()
+        results = index.search(_random_vector(), k=5)
+        assert results == []
+
+    def test_size_tracks_added_vectors(self) -> None:
+        index = ANNIndex()
+        assert index.size == 0
+        index.add("e1", _random_vector(seed=1))
+        assert index.size == 1
+        index.add("e2", _random_vector(seed=2))
+        assert index.size == 2
+
+    def test_add_and_search_single(self) -> None:
+        index = ANNIndex()
+        vec = _random_vector(seed=42)
+        index.add("e1", vec)
+
+        results = index.search(vec, k=1)
+        assert len(results) == 1
+        assert results[0][0] == "e1"
+        assert results[0][1] == pytest.approx(1.0, abs=1e-5)
+
+    def test_search_returns_nearest(self) -> None:
+        index = ANNIndex()
+
+        # Create two distinct vectors.
+        vec_a = np.zeros(384, dtype=np.float32)
+        vec_a[0] = 1.0
+        vec_b = np.zeros(384, dtype=np.float32)
+        vec_b[1] = 1.0
+
+        index.add("a", vec_a.tobytes())
+        index.add("b", vec_b.tobytes())
+
+        # Query close to vec_a.
+        query = np.zeros(384, dtype=np.float32)
+        query[0] = 1.0
+        query[1] = 0.1
+        results = index.search(query.tobytes(), k=2)
+
+        assert results[0][0] == "a"
+        assert results[1][0] == "b"
+        assert results[0][1] > results[1][1]
+
+    def test_k_larger_than_index_size(self) -> None:
+        index = ANNIndex()
+        index.add("e1", _random_vector(seed=1))
+        results = index.search(_random_vector(seed=1), k=100)
+        assert len(results) == 1
+
+
+class TestAddBulk:
+    """Bulk insertion."""
+
+    def test_bulk_add_matches_individual(self) -> None:
+        ids = [f"e{i}" for i in range(5)]
+        vecs = [_random_vector(seed=i) for i in range(5)]
+
+        idx_individual = ANNIndex()
+        for eid, v in zip(ids, vecs):
+            idx_individual.add(eid, v)
+
+        idx_bulk = ANNIndex()
+        idx_bulk.add_bulk(ids, vecs)
+
+        assert idx_bulk.size == idx_individual.size
+
+        query = _random_vector(seed=99)
+        res_ind = idx_individual.search(query, k=3)
+        res_bulk = idx_bulk.search(query, k=3)
+
+        assert [r[0] for r in res_ind] == [r[0] for r in res_bulk]
+
+    def test_bulk_add_empty(self) -> None:
+        index = ANNIndex()
+        index.add_bulk([], [])
+        assert index.size == 0
+
+
+class TestZeroVector:
+    """Edge case: zero vectors should not cause errors."""
+
+    def test_add_zero_vector(self) -> None:
+        index = ANNIndex()
+        zero = np.zeros(384, dtype=np.float32).tobytes()
+        index.add("z", zero)
+        results = index.search(zero, k=1)
+        assert len(results) == 1
+
+    def test_search_with_zero_query(self) -> None:
+        index = ANNIndex()
+        index.add("e1", _random_vector(seed=1))
+        zero = np.zeros(384, dtype=np.float32).tobytes()
+        results = index.search(zero, k=1)
+        assert len(results) == 1
+
+
+class TestFAISSDetection:
+    """Verify FAISS availability flag."""
+
+    def test_faiss_flag_is_boolean(self) -> None:
+        assert isinstance(FAISS_AVAILABLE, bool)
+
+
+class TestSearchEngineIntegration:
+    """Integration test: ANN index produces same results as old brute-force."""
+
+    def test_semantic_search_through_engine(self) -> None:
+        """Verify SearchEngine still returns correct entities via ANN path."""
+        store = Store(":memory:")
+        config = SearchConfig()
+        emb = EmbeddingEngine()
+
+        csv_content = (
+            "name,role,notes\n"
+            "Alice,Engineer,Python data pipeline developer\n"
+            "Bob,Architect,Cloud infrastructure and DevOps\n"
+            "Eve,Scientist,Machine learning researcher\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write(csv_content)
+            csv_path = Path(f.name)
+
+        try:
+            conn = CsvLocalConnector()
+            conn.authenticate({"path": str(csv_path)})
+            discovered = conn.discover()
+            for entity in discovered:
+                store.put_entity(entity)
+            for record in conn.read(discovered[0].id):
+                store.put_entity(record)
+                emb.embed_entity(record, store)
+
+            engine = SearchEngine(store, config, embedding_engine=emb)
+            results = engine.search("artificial intelligence", limit=5)
+
+            # Should find Eve (ML researcher) semantically.
+            names = [e.get_signal_value("field:name") for e in results]
+            assert "Eve" in names
+        finally:
+            csv_path.unlink()
+            store.close()


### PR DESCRIPTION
## Summary
- Add `ANNIndex` class backed by FAISS `IndexFlatIP` for fast approximate nearest neighbor search, with brute-force fallback when FAISS is not installed
- Replace brute-force cosine similarity in `SearchEngine._semantic_search` with the new ANN index
- Add `faiss-cpu` as an optional dependency (`pip install brij[ann]`)

Closes #54

## Test plan
- [x] 11 new tests in `tests/search/test_ann_index.py` (unit + integration)
- [x] All 366 existing tests pass — no regressions
- [x] Lint passes (`ruff check brij/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)