### PR TITLE
feat: incremental sync via last_sync_timestamp per source (#55)

### DIFF
--- a/brij/cli.py
+++ b/brij/cli.py
@@ -132,6 +132,11 @@ def connect(ctx: click.Context, connector_name: str, path: str | None, verbose: 
             source_id, connector_name, creds_json, total_collections=len(collections),
         )
 
+        # Persist initial sync state for future incremental syncs.
+        state = connector.get_sync_state()
+        if state:
+            store.put_sync_state(source_id, state)
+
         click.echo(
             f"Connected {connector_name}: {len(entities)} entities cataloged. "
             f"Indexing {len(collections)} collection(s) in the background."
@@ -212,6 +217,99 @@ def status(ctx: click.Context, verbose: bool) -> None:
 
             if src.get("last_synced_at"):
                 click.echo(f"    last synced: {src['last_synced_at']}")
+    finally:
+        store.close()
+
+
+@main.command()
+@click.argument("source_id")
+@click.option("--verbose", "-v", is_flag=True, help="Enable debug logging.")
+@click.pass_context
+def sync(ctx: click.Context, source_id: str, verbose: bool) -> None:
+    """Incrementally sync a connected source."""
+    _setup_logging(ctx, verbose)
+    _ensure_builtins_registered()
+    discover_connectors()
+
+    config = Config.load()
+    if not config.db_path.exists():
+        click.echo("No database found. Connect a source first with: brij connect")
+        return
+
+    store = _get_store(config)
+    try:
+        sources = store.get_sources()
+        source = next((s for s in sources if s["id"] == source_id), None)
+        if source is None:
+            click.echo(f"Unknown source: {source_id}", err=True)
+            sys.exit(1)
+
+        connector_cls = get_connector(source["connector_type"])
+        if connector_cls is None:
+            click.echo(
+                f"Unknown connector type: {source['connector_type']}", err=True,
+            )
+            sys.exit(1)
+
+        connector = connector_cls()
+        creds = json.loads(source["config"]) if source.get("config") else {}
+        try:
+            connector.authenticate(creds)
+        except Exception as exc:
+            click.echo(f"Authentication failed: {exc}", err=True)
+            sys.exit(1)
+
+        # Load persisted sync state into the connector.
+        saved_state = store.get_sync_state(source_id)
+        if saved_state:
+            connector.set_sync_state(saved_state)
+
+        sync_result = connector.sync()
+
+        total_changes = (
+            len(sync_result.new) + len(sync_result.modified) + len(sync_result.deleted)
+        )
+        if total_changes == 0:
+            # Persist any updated state (e.g. refreshed change tokens).
+            state = connector.get_sync_state()
+            if state:
+                store.put_sync_state(source_id, state)
+            click.echo("Already up to date.")
+            return
+
+        click.echo(
+            f"Changes detected: {len(sync_result.new)} new, "
+            f"{len(sync_result.modified)} modified, "
+            f"{len(sync_result.deleted)} deleted"
+        )
+
+        # Re-discover to update Tier 1 metadata for changed entities.
+        entities = connector.discover()
+        for entity in entities:
+            if entity.id in set(sync_result.new + sync_result.modified):
+                store.put_entity(entity)
+
+        task_id = store.create_indexing_task(
+            source_id,
+            source["connector_type"],
+            source.get("config"),
+            total_collections=len(sync_result.new) + len(sync_result.modified),
+        )
+
+        click.echo(
+            f"Indexing {len(sync_result.new) + len(sync_result.modified)} "
+            f"collection(s) in the background."
+        )
+
+        worker = IndexingWorker(
+            db_path=config.db_path,
+            connector=connector,
+            source_id=source_id,
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
     finally:
         store.close()
 

--- a/brij/connectors/base.py
+++ b/brij/connectors/base.py
@@ -124,6 +124,20 @@ class BaseConnector(ABC):
             f"{type(self).__name__} does not support collection creation"
         )
 
+    def get_sync_state(self) -> dict[str, str]:
+        """Return the current sync state for persistence.
+
+        Subclasses should override to return connector-specific state
+        (e.g. change tokens, last-modified timestamps).
+        """
+        return {}
+
+    def set_sync_state(self, state: dict[str, str]) -> None:
+        """Load persisted sync state into the connector.
+
+        Subclasses should override to restore connector-specific state.
+        """
+
     @staticmethod
     def make_entity_id(entity_type: str, source_specific_id: str) -> str:
         """Generate a formatted entity ID string.

--- a/brij/connectors/csv_local.py
+++ b/brij/connectors/csv_local.py
@@ -417,6 +417,18 @@ class CsvLocalConnector(BaseConnector):
         logger.info("Created collection %s at %s", name, new_path)
         return collection
 
+    def get_sync_state(self) -> dict[str, str]:
+        """Return the last-modified timestamp for persistence."""
+        if self._last_modified is not None:
+            return {"last_modified": self._last_modified.isoformat()}
+        return {}
+
+    def set_sync_state(self, state: dict[str, str]) -> None:
+        """Restore the last-modified timestamp from persisted state."""
+        ts = state.get("last_modified")
+        if ts:
+            self._last_modified = datetime.fromisoformat(ts)
+
     def sync(self) -> SyncResult:
         """Compare file modification time against stored timestamp.
 

--- a/brij/connectors/google_drive.py
+++ b/brij/connectors/google_drive.py
@@ -92,6 +92,7 @@ class GoogleDriveConnector(BaseConnector):
         self._token_path: Path = TOKEN_PATH
         self._last_modified: dict[str, datetime] = {}
         self._folder_cache: dict[str, dict[str, str]] = {}
+        self._change_token: str | None = None
 
     def authenticate(self, credentials: dict) -> None:
         """Authenticate with Google Drive API via OAuth.
@@ -755,13 +756,77 @@ class GoogleDriveConnector(BaseConnector):
         """
         raise WriteError("Google Drive connector is read-only (metadata catalog)")
 
-    def sync(self) -> SyncResult:
-        """Check for modified files since last discover.
+    def get_sync_state(self) -> dict[str, str]:
+        """Return change token and per-file last-modified timestamps for persistence."""
+        state: dict[str, str] = {}
+        if self._change_token:
+            state["change_token"] = self._change_token
+        for fid, ts in self._last_modified.items():
+            state[f"last_modified:{fid}"] = ts.isoformat()
+        return state
 
-        Uses the Drive API modification timestamp to detect changes.
+    def set_sync_state(self, state: dict[str, str]) -> None:
+        """Restore change token and per-file timestamps from persisted state."""
+        self._change_token = state.get("change_token")
+        prefix = "last_modified:"
+        for key, value in state.items():
+            if key.startswith(prefix):
+                fid = key[len(prefix):]
+                self._last_modified[fid] = datetime.fromisoformat(value)
+
+    def _get_start_page_token(self) -> str | None:
+        """Fetch a start page token from the Drive changes API."""
+        try:
+            response = self._service.changes().getStartPageToken().execute()
+            return response.get("startPageToken")
+        except Exception:
+            logger.warning("Failed to get Drive changes start page token")
+            return None
+
+    def _list_changes(self, page_token: str) -> tuple[list[dict], list[str], str | None]:
+        """List changes since the given page token.
 
         Returns:
-            SyncResult with modified file collection IDs.
+            Tuple of (changed_files, removed_file_ids, new_page_token).
+        """
+        changed: list[dict] = []
+        removed: list[str] = []
+        current_token = page_token
+
+        while current_token:
+            try:
+                response = self._service.changes().list(
+                    pageToken=current_token,
+                    fields=(
+                        "nextPageToken, newStartPageToken, "
+                        f"changes(fileId, removed, file({_FILE_FIELDS}))"
+                    ),
+                    pageSize=_PAGE_SIZE,
+                ).execute()
+            except Exception:
+                logger.warning("Failed to list Drive changes")
+                return changed, removed, None
+
+            for change in response.get("changes", []):
+                if change.get("removed"):
+                    removed.append(change["fileId"])
+                elif change.get("file"):
+                    changed.append(change["file"])
+
+            current_token = response.get("nextPageToken")
+
+        new_token = response.get("newStartPageToken")
+        return changed, removed, new_token
+
+    def sync(self) -> SyncResult:
+        """Check for changes since last sync.
+
+        Uses Drive change tokens when available for efficient incremental
+        detection. Falls back to modification timestamp comparison when no
+        change token is stored.
+
+        Returns:
+            SyncResult with new, modified, and deleted file collection IDs.
 
         Raises:
             AuthenticationError: If authenticate() has not been called.
@@ -769,8 +834,55 @@ class GoogleDriveConnector(BaseConnector):
         if self._service is None:
             raise AuthenticationError("authenticate() must be called before sync()")
 
+        # Use change token if available for efficient incremental sync.
+        if self._change_token:
+            return self._sync_via_changes()
+
+        # Fall back to mtime comparison for first sync or missing token.
+        return self._sync_via_mtime()
+
+    def _sync_via_changes(self) -> SyncResult:
+        """Sync using the Drive changes API."""
+        changed_files, removed_ids, new_token = self._list_changes(self._change_token)
+
+        if new_token:
+            self._change_token = new_token
+
+        new: list[str] = []
+        modified: list[str] = []
+        deleted: list[str] = []
+
+        for file_meta in changed_files:
+            file_id = file_meta["id"]
+            modified_time_str = file_meta.get("modifiedTime", "")
+            collection_id = self.make_entity_id("collection", file_id)
+
+            if file_id in self._last_modified:
+                modified.append(collection_id)
+            else:
+                new.append(collection_id)
+
+            if modified_time_str:
+                self._last_modified[file_id] = datetime.fromisoformat(
+                    modified_time_str.replace("Z", "+00:00")
+                )
+
+        for file_id in removed_ids:
+            collection_id = self.make_entity_id("collection", file_id)
+            deleted.append(collection_id)
+            self._last_modified.pop(file_id, None)
+
+        return SyncResult(new=new, modified=modified, deleted=deleted)
+
+    def _sync_via_mtime(self) -> SyncResult:
+        """Sync using modification timestamp comparison (initial sync)."""
         if not self._last_modified:
             self.discover()
+
+        # Capture initial change token for future incremental syncs.
+        token = self._get_start_page_token()
+        if token:
+            self._change_token = token
 
         files = self._list_files()
         modified: list[str] = []

--- a/brij/connectors/google_sheets.py
+++ b/brij/connectors/google_sheets.py
@@ -685,6 +685,21 @@ class GoogleSheetsConnector(BaseConnector):
         logger.info("Created spreadsheet %s (%s)", name, spreadsheet_id)
         return collection
 
+    def get_sync_state(self) -> dict[str, str]:
+        """Return per-spreadsheet last-modified timestamps for persistence."""
+        return {
+            f"last_modified:{sid}": ts.isoformat()
+            for sid, ts in self._last_modified.items()
+        }
+
+    def set_sync_state(self, state: dict[str, str]) -> None:
+        """Restore per-spreadsheet last-modified timestamps from persisted state."""
+        prefix = "last_modified:"
+        for key, value in state.items():
+            if key.startswith(prefix):
+                sid = key[len(prefix):]
+                self._last_modified[sid] = datetime.fromisoformat(value)
+
     def sync(self) -> SyncResult:
         """Check for modified spreadsheets since last discover.
 

--- a/brij/core/store.py
+++ b/brij/core/store.py
@@ -65,6 +65,15 @@ CREATE TABLE IF NOT EXISTS indexing_tasks (
     FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS sync_state (
+    source_id TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (source_id, key),
+    FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS signals_fts
     USING fts5(entity_id, kind, value, tokenize='porter');
 
@@ -387,6 +396,40 @@ class Store:
                 f"UPDATE indexing_tasks SET {', '.join(updates)} WHERE id = ?",
                 params,
             )
+
+    # --- Sync state ---
+
+    def get_sync_state(self, source_id: str) -> dict[str, str]:
+        """Return all sync state key-value pairs for a source."""
+        rows = self._conn.execute(
+            "SELECT key, value FROM sync_state WHERE source_id = ?",
+            (source_id,),
+        ).fetchall()
+        return {r["key"]: r["value"] for r in rows}
+
+    def put_sync_state(self, source_id: str, state: dict[str, str]) -> None:
+        """Persist sync state key-value pairs for a source."""
+        now = _now_iso()
+        with self._conn:
+            for key, value in state.items():
+                self._conn.execute(
+                    """INSERT OR REPLACE INTO sync_state
+                       (source_id, key, value, updated_at)
+                       VALUES (?, ?, ?, ?)""",
+                    (source_id, key, value, now),
+                )
+
+    def delete_entities_for_ids(self, entity_ids: list[str]) -> int:
+        """Delete entities by their IDs. Returns number deleted."""
+        if not entity_ids:
+            return 0
+        deleted = 0
+        with self._conn:
+            for eid in entity_ids:
+                cursor = self._conn.execute("DELETE FROM entities WHERE id = ?", (eid,))
+                deleted += cursor.rowcount
+                self._conn.execute("DELETE FROM embeddings WHERE entity_id = ?", (eid,))
+        return deleted
 
     def keyword_search(
         self,

--- a/brij/core/worker.py
+++ b/brij/core/worker.py
@@ -7,7 +7,7 @@ import threading
 import time
 from pathlib import Path
 
-from brij.connectors.base import BaseConnector
+from brij.connectors.base import BaseConnector, SyncResult
 from brij.core.store import Store
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,10 @@ class IndexingWorker:
     full records from each collection and stores them.  Progress is
     tracked in the ``indexing_tasks`` table so ``brij status`` can
     report it.
+
+    Supports incremental mode: when a ``sync_result`` is provided,
+    only new and modified collections are re-indexed and deleted
+    entities are removed.
     """
 
     def __init__(
@@ -33,12 +37,14 @@ class IndexingWorker:
         task_id: int,
         *,
         rate_limit_delay: float = DEFAULT_RATE_LIMIT_DELAY,
+        sync_result: SyncResult | None = None,
     ) -> None:
         self._db_path = db_path
         self._connector = connector
         self._source_id = source_id
         self._task_id = task_id
         self._rate_limit_delay = rate_limit_delay
+        self._sync_result = sync_result
         self._thread: threading.Thread | None = None
 
     def start(self) -> None:
@@ -65,11 +71,18 @@ class IndexingWorker:
         """Main worker loop — process collections for this source."""
         store = Store(self._db_path)
         try:
-            self._process(store)
+            if self._sync_result is not None:
+                self._process_incremental(store, self._sync_result)
+            else:
+                self._process(store)
         except Exception as exc:
             logger.error("Background indexing failed for %s: %s", self._source_id, exc)
             store.update_indexing_task(self._task_id, status="failed", error=str(exc))
         finally:
+            # Persist connector sync state after indexing.
+            state = self._connector.get_sync_state()
+            if state:
+                store.put_sync_state(self._source_id, state)
             store.close()
 
     def _process(self, store: Store) -> None:
@@ -124,3 +137,81 @@ class IndexingWorker:
             collections_indexed,
             records_stored,
         )
+
+    def _process_incremental(self, store: Store, sync_result: SyncResult) -> None:
+        """Re-index only new/modified collections and remove deleted ones."""
+        store.update_indexing_task(self._task_id, status="running")
+
+        changed_ids = set(sync_result.new + sync_result.modified)
+
+        # Remove deleted entities and their children/embeddings.
+        if sync_result.deleted:
+            self._remove_deleted(store, sync_result.deleted)
+
+        # Filter to only collections that changed.
+        collections = [
+            e for e in store.get_entities_by_source(self._source_id)
+            if e.type == "collection" and e.id in changed_ids
+        ]
+
+        store.update_indexing_task(
+            self._task_id, total_collections=len(collections),
+        )
+
+        records_stored = 0
+        collections_indexed = 0
+
+        for collection in collections:
+            try:
+                # Remove old records for this collection before re-reading.
+                old_children = store.get_children(collection.id)
+                old_child_ids = [c.id for c in old_children if c.type == "record"]
+                if old_child_ids:
+                    store.delete_entities_for_ids(old_child_ids)
+
+                records = self._connector.read(collection.id)
+                for record in records:
+                    store.put_entity(record)
+                    records_stored += 1
+
+                collections_indexed += 1
+                store.update_indexing_task(
+                    self._task_id,
+                    collections_indexed=collections_indexed,
+                    records_stored=records_stored,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to re-index collection %s: %s", collection.id, exc,
+                )
+                collections_indexed += 1
+                store.update_indexing_task(
+                    self._task_id,
+                    collections_indexed=collections_indexed,
+                )
+
+            if self._rate_limit_delay > 0:
+                time.sleep(self._rate_limit_delay)
+
+        store.update_indexing_task(self._task_id, status="completed")
+        store.update_source_synced(self._source_id)
+        logger.info(
+            "Incremental indexing complete for %s: "
+            "%d new, %d modified, %d deleted, %d records stored",
+            self._source_id,
+            len(sync_result.new),
+            len(sync_result.modified),
+            len(sync_result.deleted),
+            records_stored,
+        )
+
+    def _remove_deleted(self, store: Store, deleted_ids: list[str]) -> None:
+        """Remove deleted collections and all their children."""
+        for collection_id in deleted_ids:
+            children = store.get_children(collection_id)
+            child_ids = [c.id for c in children]
+            if child_ids:
+                store.delete_entities_for_ids(child_ids)
+            store.delete_entities_for_ids([collection_id])
+            logger.debug("Removed deleted collection %s and %d children",
+                         collection_id, len(child_ids))

--- a/tests/core/test_incremental_sync.py
+++ b/tests/core/test_incremental_sync.py
@@ -1,0 +1,461 @@
+"""Tests for incremental sync: sync state persistence, incremental worker, and connector state."""
+
+from __future__ import annotations
+
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from brij.connectors.base import BaseConnector, SyncResult
+from brij.connectors.csv_local import CsvLocalConnector
+from brij.core.models import Entity, Signal
+from brij.core.store import Store
+from brij.core.worker import IndexingWorker
+
+
+# --- Helpers ---
+
+
+class FakeConnector(BaseConnector):
+    """Connector that returns canned records and tracks sync state."""
+
+    def __init__(
+        self,
+        records_by_collection: dict[str, list[Entity]] | None = None,
+        sync_result: SyncResult | None = None,
+    ):
+        self._records = records_by_collection or {}
+        self._sync_result = sync_result or SyncResult()
+        self._state: dict[str, str] = {}
+
+    def authenticate(self, credentials: dict) -> None:
+        pass
+
+    def discover(self) -> list[Entity]:
+        return []
+
+    def read(self, entity_id: str) -> list[Entity]:
+        return self._records.get(entity_id, [])
+
+    def write(self, entity_id: str, data: dict) -> bool:
+        return True
+
+    def sync(self) -> SyncResult:
+        return self._sync_result
+
+    def get_sync_state(self) -> dict[str, str]:
+        return dict(self._state)
+
+    def set_sync_state(self, state: dict[str, str]) -> None:
+        self._state = dict(state)
+
+
+def _make_collection(collection_id: str, source_id: str = "src1") -> Entity:
+    return Entity(
+        id=collection_id,
+        type="collection",
+        source_id=source_id,
+        signals=[Signal(kind="name", value=collection_id)],
+    )
+
+
+def _make_record(
+    record_id: str, source_id: str = "src1", parent_id: str = "col1"
+) -> Entity:
+    return Entity(
+        id=record_id,
+        type="record",
+        source_id=source_id,
+        parent_id=parent_id,
+        signals=[Signal(kind="field:name", value="test")],
+    )
+
+
+@pytest.fixture
+def store():
+    s = Store(":memory:")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return tmp_path / "test.db"
+
+
+# --- Store sync_state tests ---
+
+
+class TestSyncStatePersistence:
+    def test_put_and_get_sync_state(self, store):
+        store.add_source("src1", "src1", "csv_local")
+        store.put_sync_state("src1", {"last_modified": "2024-01-01T00:00:00+00:00"})
+
+        state = store.get_sync_state("src1")
+        assert state == {"last_modified": "2024-01-01T00:00:00+00:00"}
+
+    def test_get_empty_state(self, store):
+        store.add_source("src1", "src1", "csv_local")
+        state = store.get_sync_state("src1")
+        assert state == {}
+
+    def test_put_multiple_keys(self, store):
+        store.add_source("src1", "src1", "google_drive")
+        store.put_sync_state("src1", {
+            "change_token": "abc123",
+            "last_modified:file1": "2024-01-01T00:00:00+00:00",
+            "last_modified:file2": "2024-02-01T00:00:00+00:00",
+        })
+
+        state = store.get_sync_state("src1")
+        assert len(state) == 3
+        assert state["change_token"] == "abc123"
+        assert state["last_modified:file1"] == "2024-01-01T00:00:00+00:00"
+
+    def test_put_overwrites_existing(self, store):
+        store.add_source("src1", "src1", "csv_local")
+        store.put_sync_state("src1", {"last_modified": "2024-01-01T00:00:00+00:00"})
+        store.put_sync_state("src1", {"last_modified": "2024-06-01T00:00:00+00:00"})
+
+        state = store.get_sync_state("src1")
+        assert state["last_modified"] == "2024-06-01T00:00:00+00:00"
+
+    def test_state_isolated_per_source(self, store):
+        store.add_source("src1", "src1", "csv_local")
+        store.add_source("src2", "src2", "csv_local")
+        store.put_sync_state("src1", {"key": "val1"})
+        store.put_sync_state("src2", {"key": "val2"})
+
+        assert store.get_sync_state("src1")["key"] == "val1"
+        assert store.get_sync_state("src2")["key"] == "val2"
+
+
+class TestDeleteEntitiesForIds:
+    def test_delete_entities(self, store):
+        store.put_entity(_make_record("r1"))
+        store.put_entity(_make_record("r2"))
+        store.put_entity(_make_record("r3"))
+
+        deleted = store.delete_entities_for_ids(["r1", "r2"])
+        assert deleted == 2
+        assert store.get_entity("r1") is None
+        assert store.get_entity("r2") is None
+        assert store.get_entity("r3") is not None
+
+    def test_delete_empty_list(self, store):
+        assert store.delete_entities_for_ids([]) == 0
+
+    def test_delete_removes_embeddings(self, store):
+        store.put_entity(_make_record("r1"))
+        store.put_embedding("r1", b"\x00" * 16, "test-model")
+        assert store.get_embedding("r1") is not None
+
+        store.delete_entities_for_ids(["r1"])
+        assert store.get_embedding("r1") is None
+
+
+# --- CSV connector sync state tests ---
+
+
+class TestCsvSyncState:
+    def test_get_sync_state_before_discover(self):
+        conn = CsvLocalConnector()
+        assert conn.get_sync_state() == {}
+
+    def test_get_sync_state_after_discover(self, tmp_path):
+        csv = tmp_path / "test.csv"
+        csv.write_text("a,b\n1,2\n")
+
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv)})
+        conn.discover()
+
+        state = conn.get_sync_state()
+        assert "last_modified" in state
+
+    def test_set_sync_state_restores_baseline(self, tmp_path):
+        csv = tmp_path / "test.csv"
+        csv.write_text("a,b\n1,2\n")
+
+        # First connector discovers and gets state.
+        conn1 = CsvLocalConnector()
+        conn1.authenticate({"path": str(csv)})
+        conn1.discover()
+        state = conn1.get_sync_state()
+
+        # Second connector restores state — sync should show no changes.
+        conn2 = CsvLocalConnector()
+        conn2.authenticate({"path": str(csv)})
+        conn2.set_sync_state(state)
+        result = conn2.sync()
+        assert result.modified == []
+
+    def test_set_sync_state_detects_changes(self, tmp_path):
+        csv = tmp_path / "test.csv"
+        csv.write_text("a,b\n1,2\n")
+
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv)})
+        # Set old state so file appears modified.
+        conn.set_sync_state({"last_modified": "2020-01-01T00:00:00+00:00"})
+        result = conn.sync()
+        assert len(result.modified) == 1
+
+
+# --- Incremental worker tests ---
+
+
+class TestIncrementalWorker:
+    def test_incremental_only_indexes_changed(self, tmp_db):
+        """Worker with sync_result only re-indexes new/modified collections."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+
+        col1 = _make_collection("col1")
+        col2 = _make_collection("col2")
+        store.put_entity(col1)
+        store.put_entity(col2)
+
+        # Only col1 was modified.
+        sync_result = SyncResult(modified=["col1"])
+
+        new_records = [_make_record("r_new", parent_id="col1")]
+        connector = FakeConnector(records_by_collection={"col1": new_records})
+
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        task = store.get_indexing_task(task_id)
+        assert task["status"] == "completed"
+        assert task["total_collections"] == 1  # Only col1 was re-indexed.
+        assert task["records_stored"] == 1
+        assert store.get_entity("r_new") is not None
+        store.close()
+
+    def test_incremental_removes_deleted(self, tmp_db):
+        """Worker removes deleted collections and their children."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+
+        col1 = _make_collection("col1")
+        store.put_entity(col1)
+        store.put_entity(_make_record("r1", parent_id="col1"))
+        store.put_entity(_make_record("r2", parent_id="col1"))
+
+        sync_result = SyncResult(deleted=["col1"])
+        connector = FakeConnector()
+
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        assert store.get_entity("col1") is None
+        assert store.get_entity("r1") is None
+        assert store.get_entity("r2") is None
+        task = store.get_indexing_task(task_id)
+        assert task["status"] == "completed"
+        store.close()
+
+    def test_incremental_replaces_old_records(self, tmp_db):
+        """Modified collection's old records are removed before new ones stored."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+
+        col1 = _make_collection("col1")
+        store.put_entity(col1)
+        store.put_entity(_make_record("old_r1", parent_id="col1"))
+        store.put_entity(_make_record("old_r2", parent_id="col1"))
+
+        sync_result = SyncResult(modified=["col1"])
+        new_records = [_make_record("new_r1", parent_id="col1")]
+        connector = FakeConnector(records_by_collection={"col1": new_records})
+
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        # Old records removed, new one present.
+        assert store.get_entity("old_r1") is None
+        assert store.get_entity("old_r2") is None
+        assert store.get_entity("new_r1") is not None
+        store.close()
+
+    def test_incremental_persists_sync_state(self, tmp_db):
+        """Worker persists connector sync state after completion."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+
+        col1 = _make_collection("col1")
+        store.put_entity(col1)
+
+        sync_result = SyncResult(modified=["col1"])
+        connector = FakeConnector(records_by_collection={"col1": []})
+        connector._state = {"change_token": "tok123"}
+
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        state = store.get_sync_state("src1")
+        assert state["change_token"] == "tok123"
+        store.close()
+
+    def test_incremental_with_new_collections(self, tmp_db):
+        """Worker indexes new collections from sync result."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+
+        col_new = _make_collection("col_new")
+        store.put_entity(col_new)
+
+        sync_result = SyncResult(new=["col_new"])
+        records = [_make_record("r1", parent_id="col_new")]
+        connector = FakeConnector(records_by_collection={"col_new": records})
+
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        task = store.get_indexing_task(task_id)
+        assert task["status"] == "completed"
+        assert task["records_stored"] == 1
+        assert store.get_entity("r1") is not None
+        store.close()
+
+    def test_incremental_no_changes(self, tmp_db):
+        """Worker completes immediately when sync result has no changes."""
+        store = Store(tmp_db)
+        store.add_source("src1", "src1", "fake", "{}")
+        connector = FakeConnector()
+
+        sync_result = SyncResult()  # No changes.
+        task_id = store.create_indexing_task("src1", "fake", "{}")
+        store.close()
+
+        worker = IndexingWorker(
+            db_path=tmp_db,
+            connector=connector,
+            source_id="src1",
+            task_id=task_id,
+            rate_limit_delay=0.0,
+            sync_result=sync_result,
+        )
+        worker.start()
+        worker.join(timeout=5.0)
+
+        store = Store(tmp_db)
+        task = store.get_indexing_task(task_id)
+        assert task["status"] == "completed"
+        assert task["records_stored"] == 0
+        store.close()
+
+
+# --- End-to-end CSV incremental sync test ---
+
+
+class TestCsvIncrementalEndToEnd:
+    def test_csv_sync_round_trip(self, tmp_path):
+        """Full cycle: connect → modify file → sync → only changed re-indexed."""
+        csv = tmp_path / "data.csv"
+        csv.write_text("name,email\nAlice,a@x.com\n")
+        db_path = tmp_path / "brij.db"
+
+        # Phase 1: Initial connect.
+        store = Store(db_path)
+        conn = CsvLocalConnector()
+        conn.authenticate({"path": str(csv)})
+        entities = conn.discover()
+
+        source_id = entities[0].source_id
+        store.add_source(source_id, source_id, "csv_local", '{"path": "' + str(csv) + '"}')
+        for e in entities:
+            store.put_entity(e)
+
+        # Persist initial sync state.
+        store.put_sync_state(source_id, conn.get_sync_state())
+        store.close()
+
+        # Phase 2: Modify the file.
+        time.sleep(0.05)
+        csv.write_text("name,email\nAlice,a@x.com\nBob,b@x.com\n")
+
+        # Phase 3: Incremental sync.
+        store = Store(db_path)
+        conn2 = CsvLocalConnector()
+        conn2.authenticate({"path": str(csv)})
+
+        saved_state = store.get_sync_state(source_id)
+        conn2.set_sync_state(saved_state)
+
+        result = conn2.sync()
+        assert len(result.modified) == 1
+
+        # Persist updated state.
+        store.put_sync_state(source_id, conn2.get_sync_state())
+
+        # Phase 4: Sync again — no changes.
+        conn3 = CsvLocalConnector()
+        conn3.authenticate({"path": str(csv)})
+        conn3.set_sync_state(store.get_sync_state(source_id))
+        result2 = conn3.sync()
+        assert result2.modified == []
+
+        store.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,6 +211,60 @@ class TestStatus:
         assert "indexing:" in result.output
 
 
+class TestSync:
+    def test_sync_no_db(self, runner: CliRunner, config: Config) -> None:
+        with _patch_config(config):
+            result = runner.invoke(main, ["sync", "src1"])
+
+        assert result.exit_code == 0
+        assert "No database found" in result.output
+
+    def test_sync_unknown_source(
+        self, runner: CliRunner, config: Config
+    ) -> None:
+        Store(config.db_path).close()
+
+        with _patch_config(config):
+            result = runner.invoke(main, ["sync", "nonexistent"])
+
+        assert result.exit_code != 0
+        assert "Unknown source" in result.output
+
+    def test_sync_no_changes(
+        self, runner: CliRunner, clients_csv: Path, config: Config
+    ) -> None:
+        """Sync with no file changes reports up to date."""
+        with _patch_config(config):
+            runner.invoke(main, ["connect", "csv_local", "--path", str(clients_csv)])
+            time.sleep(0.5)
+            result = runner.invoke(main, ["sync", f"csv:{clients_csv.name}"])
+
+        assert result.exit_code == 0
+        assert "up to date" in result.output
+
+    def test_sync_detects_changes(
+        self, runner: CliRunner, clients_csv: Path, config: Config
+    ) -> None:
+        """Sync after file modification reports changes."""
+        with _patch_config(config):
+            runner.invoke(main, ["connect", "csv_local", "--path", str(clients_csv)])
+            time.sleep(0.5)
+
+            # Modify the file.
+            time.sleep(0.05)
+            clients_csv.write_text(
+                "name,email,phone\n"
+                "Alice,alice@example.com,555-1234\n"
+                "Carol,carol@example.com,555-9999\n"
+            )
+
+            result = runner.invoke(main, ["sync", f"csv:{clients_csv.name}"])
+
+        assert result.exit_code == 0
+        assert "modified" in result.output
+        assert "background" in result.output
+
+
 class TestSearch:
     def test_search_no_db(self, runner: CliRunner, config: Config) -> None:
         with _patch_config(config):


### PR DESCRIPTION
## Summary
- Adds `sync_state` table to persist connector-specific state (timestamps, change tokens) between syncs
- Each connector implements `get_sync_state()`/`set_sync_state()` to serialize/restore its sync baseline
- On `brij sync <source_id>`, only files modified since last sync are fetched — Drive uses change tokens with mtime fallback, Sheets uses per-spreadsheet mtime, CSV uses file mtime
- `IndexingWorker` supports incremental mode: deletes stale records, re-indexes only changed collections
- Adds `brij sync` CLI command with full test coverage (23 new tests)

Closes #55

## Test plan
- [x] `pytest tests/core/test_incremental_sync.py` — 19 tests covering sync state persistence, entity deletion, CSV state round-trip, incremental worker (new/modified/deleted collections, state persistence)
- [x] `pytest tests/test_cli.py::TestSync` — 4 CLI tests (no db, unknown source, no changes, detects changes)
- [x] Full suite (223 tests) passes with no regressions
- [x] `ruff check brij/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)